### PR TITLE
chore: upgrade calcit to 0.13.19

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,3072 +1,588 @@
 
-{} (:package |app)
-  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |app.main/main!) (:output |src) (:port 6001) (:reload-fn |app.main/reload!) (:storage-key |calcit.cirru)
-    :modules $ [] |lilac/compact.cirru |memof/compact.cirru |respo.calcit/compact.cirru |respo-ui.calcit/compact.cirru |respo-markdown.calcit/compact.cirru |calcit-theme.calcit/compact.cirru |reel.calcit/compact.cirru |respo-feather.calcit/
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app) (:version |0.0.1)
   :entries $ {}
+    :default $ {} (:description |) (:init-fn 'app.main/main!) (:mode :native) (:reload-fn 'app.main/reload!)
+      :modules $ [] |lilac/compact.cirru |memof/compact.cirru |respo.calcit/compact.cirru |respo-ui.calcit/compact.cirru |respo-markdown.calcit/compact.cirru |calcit-theme.calcit/compact.cirru |reel.calcit/compact.cirru |respo-feather.calcit/
+      :type-slots $ {}
   :files $ {}
-    |app.comp.container $ %{} :FileEntry
+    |app.comp.container $ %{} 'FileEntry
       :defs $ {}
-        |comp-api-entry $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1603363205264) (:by |rJG4IHzWf) (:text |defcomp)
-              |j $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |comp-api-entry)
-              |n $ %{} :Expr (:at 1603363206065) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1603363216442) (:by |rJG4IHzWf) (:text |info)
-                  |j $ %{} :Leaf (:at 1604977645146) (:by |rJG4IHzWf) (:text |syntax)
-              |r $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |div)
-                  |j $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |{})
-                      |n $ %{} :Expr (:at 1690397601895) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690397604707) (:by |rJG4IHzWf) (:text |:class-name)
-                          |b $ %{} :Expr (:at 1690397703647) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |D $ %{} :Leaf (:at 1690397705338) (:by |rJG4IHzWf) (:text |str-spaced)
-                              |L $ %{} :Leaf (:at 1690397706535) (:by |rJG4IHzWf) (:text |css/row)
-                              |T $ %{} :Leaf (:at 1690397606673) (:by |rJG4IHzWf) (:text |css-api-entry)
-                              |b $ %{} :Expr (:at 1736442121367) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1736442121367) (:by |rJG4IHzWf) (:text |if)
-                                  |b $ %{} :Expr (:at 1736442121367) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1736442121367) (:by |rJG4IHzWf) (:text |:wip?)
-                                      |b $ %{} :Leaf (:at 1736442121367) (:by |rJG4IHzWf) (:text |info)
-                                  |h $ %{} :Leaf (:at 1736442131105) (:by |rJG4IHzWf) (:text |css-api-entry-wip)
-                  |r $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |div)
-                      |j $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |{})
-                          |j $ %{} :Expr (:at 1628674665840) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476029822) (:by |rJG4IHzWf) (:text |:class-name)
-                              |j $ %{} :Leaf (:at 1690476032097) (:by |rJG4IHzWf) (:text |css/flex)
-                      |r $ %{} :Expr (:at 1692287573224) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |D $ %{} :Leaf (:at 1692287574371) (:by |rJG4IHzWf) (:text |div)
-                          |L $ %{} :Expr (:at 1692287574651) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287575060) (:by |rJG4IHzWf) (:text |{})
-                              |b $ %{} :Expr (:at 1692287592864) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1692287594288) (:by |rJG4IHzWf) (:text |:class-name)
-                                  |b $ %{} :Leaf (:at 1692287598171) (:by |rJG4IHzWf) (:text |css/row-middle)
-                          |T $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |<>)
-                              |j $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |:name)
-                                  |j $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |info)
-                              |n $ %{} :Leaf (:at 1690476193816) (:by |rJG4IHzWf) (:text |css/font-code)
-                          |b $ %{} :Expr (:at 1692287581336) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |list->)
-                              |b $ %{} :Expr (:at 1692287581336) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |{})
-                                  |b $ %{} :Expr (:at 1692287581336) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |:class-name)
-                                      |b $ %{} :Expr (:at 1692287581336) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |str-spaced)
-                                          |b $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |css/row-middle)
-                                          |h $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |style-tags)
-                                          |l $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |css/font-fancy!)
-                                  |h $ %{} :Expr (:at 1692287698713) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1692287718658) (:by |rJG4IHzWf) (:text |:style)
-                                      |b $ %{} :Expr (:at 1692287719238) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |D $ %{} :Leaf (:at 1692287720208) (:by |rJG4IHzWf) (:text |{})
-                                          |T $ %{} :Expr (:at 1692287720648) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |D $ %{} :Leaf (:at 1692287723572) (:by |rJG4IHzWf) (:text |:margin-top)
-                                              |T $ %{} :Leaf (:at 1692287726325) (:by |rJG4IHzWf) (:text |2)
-                              |h $ %{} :Expr (:at 1692287581336) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |->)
-                                  |b $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |info)
-                                  |h $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |:tags)
-                                  |l $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |.to-list)
-                                  |o $ %{} :Expr (:at 1692287581336) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |map)
-                                      |b $ %{} :Expr (:at 1692287581336) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |fn)
-                                          |b $ %{} :Expr (:at 1692287581336) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |t)
-                                          |h $ %{} :Expr (:at 1692287581336) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |[])
-                                              |b $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |t)
-                                              |h $ %{} :Expr (:at 1692287581336) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |<>)
-                                                  |b $ %{} :Expr (:at 1692287581336) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |turn-string)
-                                                      |b $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |t)
-                                                  |h $ %{} :Leaf (:at 1692287581336) (:by |rJG4IHzWf) (:text |style-tag)
-                      |v $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |=<)
-                          |j $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |8)
-                          |r $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |nil)
-                      |z $ %{} :Expr (:at 1692287550107) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1692287550107) (:by |rJG4IHzWf) (:text |div)
-                          |b $ %{} :Expr (:at 1692287550107) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287550107) (:by |rJG4IHzWf) (:text |{})
-                              |b $ %{} :Expr (:at 1692287550107) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1692287550107) (:by |rJG4IHzWf) (:text |:class-name)
-                                  |b $ %{} :Expr (:at 1692287550107) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1692287550107) (:by |rJG4IHzWf) (:text |str-spaced)
-                                      |b $ %{} :Leaf (:at 1692287550107) (:by |rJG4IHzWf) (:text "|\"md-span")
-                                      |h $ %{} :Leaf (:at 1692287550107) (:by |rJG4IHzWf) (:text |css-desc)
-                          |h $ %{} :Expr (:at 1692287550107) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287550107) (:by |rJG4IHzWf) (:text |comp-md)
-                              |b $ %{} :Expr (:at 1692287550107) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1692287550107) (:by |rJG4IHzWf) (:text |either)
-                                  |b $ %{} :Expr (:at 1692287550107) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1692287550107) (:by |rJG4IHzWf) (:text |:desc)
-                                      |b $ %{} :Leaf (:at 1692287550107) (:by |rJG4IHzWf) (:text |info)
-                                  |h $ %{} :Leaf (:at 1692287550107) (:by |rJG4IHzWf) (:text "|\"TODO")
-                  |v $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1619983887236) (:by |rJG4IHzWf) (:text |div)
-                      |j $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1690476174178) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476176909) (:by |rJG4IHzWf) (:text |:class-name)
-                              |b $ %{} :Expr (:at 1736442199771) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |D $ %{} :Leaf (:at 1736442201928) (:by |rJG4IHzWf) (:text |str-spaced)
-                                  |T $ %{} :Leaf (:at 1690476179276) (:by |rJG4IHzWf) (:text |css/expand)
-                                  |b $ %{} :Leaf (:at 1736442205419) (:by |rJG4IHzWf) (:text |style-api-demo)
-                      |n $ %{} :Leaf (:at 1619983891339) (:by |rJG4IHzWf) (:text |&)
-                      |r $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1619707363192) (:by |rJG4IHzWf) (:text |->)
-                          |j $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |:snippets)
-                              |j $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |info)
-                          |r $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1619983957777) (:by |rJG4IHzWf) (:text |map)
-                              |j $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1603363201369) (:by |rJG4IHzWf) (:text |fn)
-                                  |j $ %{} :Expr (:at 1603363201369) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |j $ %{} :Leaf (:at 1625762697650) (:by |rJG4IHzWf) (:text |entry)
-                                  |r $ %{} :Expr (:at 1604978584168) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |D $ %{} :Leaf (:at 1604978584873) (:by |rJG4IHzWf) (:text |let)
-                                      |L $ %{} :Expr (:at 1604978585326) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |D $ %{} :Expr (:at 1604979656134) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1610954591586) (:by |rJG4IHzWf) (:text |code-snippet)
-                                              |j $ %{} :Expr (:at 1604979659654) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1604979660078) (:by |rJG4IHzWf) (:text |if)
-                                                  |j $ %{} :Expr (:at 1604979663040) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1625762714564) (:by |rJG4IHzWf) (:text |map?)
-                                                      |j $ %{} :Leaf (:at 1625762733370) (:by |rJG4IHzWf) (:text |entry)
-                                                  |n $ %{} :Leaf (:at 1625762737066) (:by |rJG4IHzWf) (:text |entry)
-                                                  |r $ %{} :Expr (:at 1604979664258) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1604979664717) (:by |rJG4IHzWf) (:text |{})
-                                                      |j $ %{} :Expr (:at 1604979665399) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1604979665901) (:by |rJG4IHzWf) (:text |:code)
-                                                          |j $ %{} :Leaf (:at 1625762786084) (:by |rJG4IHzWf) (:text |entry)
-                                          |T $ %{} :Expr (:at 1604978585326) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1604978585326) (:by |rJG4IHzWf) (:text |code)
-                                              |j $ %{} :Expr (:at 1604979672256) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1604979672256) (:by |rJG4IHzWf) (:text |:code)
-                                                  |j $ %{} :Leaf (:at 1610954593942) (:by |rJG4IHzWf) (:text |code-snippet)
-                                      |T $ %{} :Expr (:at 1604978977985) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |D $ %{} :Leaf (:at 1604978978614) (:by |rJG4IHzWf) (:text |div)
-                                          |L $ %{} :Expr (:at 1604978978816) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1604978979108) (:by |rJG4IHzWf) (:text |{})
-                                              |j $ %{} :Expr (:at 1628674922489) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1690476333902) (:by |rJG4IHzWf) (:text |:class-name)
-                                                  |j $ %{} :Leaf (:at 1690476336403) (:by |rJG4IHzWf) (:text |css/row)
-                                          |T $ %{} :Expr (:at 1604978963521) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |comp-code)
-                                              |j $ %{} :Expr (:at 1625762763939) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |D $ %{} :Leaf (:at 1658160410767) (:by |rJG4IHzWf) (:text |&cirru-quote:to-list)
-                                                  |T $ %{} :Leaf (:at 1604978964295) (:by |rJG4IHzWf) (:text |code)
-                                              |r $ %{} :Leaf (:at 1604978969602) (:by |rJG4IHzWf) (:text |syntax)
-                                          |b $ %{} :Expr (:at 1650965722772) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1650965722772) (:by |rJG4IHzWf) (:text |if)
-                                              |b $ %{} :Expr (:at 1650965722772) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1650965722772) (:by |rJG4IHzWf) (:text |some?)
-                                                  |b $ %{} :Expr (:at 1650965722772) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1650965722772) (:by |rJG4IHzWf) (:text |:desc)
-                                                      |b $ %{} :Leaf (:at 1650965722772) (:by |rJG4IHzWf) (:text |code-snippet)
-                                              |h $ %{} :Expr (:at 1650965722772) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |D $ %{} :Leaf (:at 1736441840432) (:by |rJG4IHzWf) (:text |;)
-                                                  |T $ %{} :Leaf (:at 1650965722772) (:by |rJG4IHzWf) (:text |<>)
-                                                  |b $ %{} :Expr (:at 1650965722772) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1650965722772) (:by |rJG4IHzWf) (:text |:desc)
-                                                      |b $ %{} :Leaf (:at 1650965722772) (:by |rJG4IHzWf) (:text |code-snippet)
-                                              |l $ %{} :Expr (:at 1736441865111) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |D $ %{} :Leaf (:at 1736441868908) (:by |rJG4IHzWf) (:text |div)
-                                                  |L $ %{} :Expr (:at 1736441869264) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1736441869568) (:by |rJG4IHzWf) (:text |{})
-                                                      |b $ %{} :Expr (:at 1736441871431) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1736441949022) (:by |rJG4IHzWf) (:text |:class-name)
-                                                          |b $ %{} :Leaf (:at 1736441957847) (:by |rJG4IHzWf) (:text |style-desc)
-                                                  |T $ %{} :Expr (:at 1736441852174) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1736441852469) (:by |rJG4IHzWf) (:text |comp-md)
-                                                      |b $ %{} :Expr (:at 1736441856234) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1736441855010) (:by |rJG4IHzWf) (:text |:desc)
-                                                          |b $ %{} :Leaf (:at 1736441857826) (:by |rJG4IHzWf) (:text |code-snippet)
-                                          |j $ %{} :Expr (:at 1604979043131) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |D $ %{} :Leaf (:at 1604979043704) (:by |rJG4IHzWf) (:text |if)
-                                              |L $ %{} :Expr (:at 1604979050238) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |D $ %{} :Leaf (:at 1604979051964) (:by |rJG4IHzWf) (:text |and)
-                                                  |T $ %{} :Expr (:at 1604979044537) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1604979046170) (:by |rJG4IHzWf) (:text |map?)
-                                                      |j $ %{} :Leaf (:at 1610954595347) (:by |rJG4IHzWf) (:text |code-snippet)
-                                                  |j $ %{} :Expr (:at 1604979056497) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1604979062069) (:by |rJG4IHzWf) (:text |some?)
-                                                      |j $ %{} :Expr (:at 1604979062435) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1604979063200) (:by |rJG4IHzWf) (:text |:result)
-                                                          |j $ %{} :Leaf (:at 1610954597215) (:by |rJG4IHzWf) (:text |code-snippet)
-                                              |T $ %{} :Expr (:at 1604978981439) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1604978982059) (:by |rJG4IHzWf) (:text |div)
-                                                  |j $ %{} :Expr (:at 1604978985823) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1604978985628) (:by |rJG4IHzWf) (:text |{})
-                                                      |j $ %{} :Expr (:at 1604978988265) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1690476340902) (:by |rJG4IHzWf) (:text |:class-name)
-                                                          |j $ %{} :Leaf (:at 1690476342731) (:by |rJG4IHzWf) (:text |css/row)
-                                                  |r $ %{} :Expr (:at 1604979092814) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |D $ %{} :Leaf (:at 1604979093558) (:by |rJG4IHzWf) (:text |div)
-                                                      |L $ %{} :Expr (:at 1604979093782) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1604979094136) (:by |rJG4IHzWf) (:text |{})
-                                                          |j $ %{} :Expr (:at 1604979095216) (:by |rJG4IHzWf)
-                                                            :data $ {}
-                                                              |T $ %{} :Leaf (:at 1736442087056) (:by |rJG4IHzWf) (:text |:class-name)
-                                                              |b $ %{} :Leaf (:at 1736442096700) (:by |rJG4IHzWf) (:text |style-api-result)
-                                                      |j $ %{} :Expr (:at 1629543937086) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1629543938662) (:by |rJG4IHzWf) (:text |comp-i)
-                                                          |j $ %{} :Leaf (:at 1629544459535) (:by |rJG4IHzWf) (:text |:arrow-right-circle)
-                                                          |r $ %{} :Leaf (:at 1629544295606) (:by |rJG4IHzWf) (:text |16)
-                                                          |v $ %{} :Expr (:at 1629544299271) (:by |rJG4IHzWf)
-                                                            :data $ {}
-                                                              |T $ %{} :Leaf (:at 1629544299271) (:by |rJG4IHzWf) (:text |hsl)
-                                                              |j $ %{} :Leaf (:at 1629544299271) (:by |rJG4IHzWf) (:text |200)
-                                                              |r $ %{} :Leaf (:at 1629544299271) (:by |rJG4IHzWf) (:text |0)
-                                                              |v $ %{} :Leaf (:at 1629544299271) (:by |rJG4IHzWf) (:text |50)
-                                                  |v $ %{} :Expr (:at 1604979639646) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |D $ %{} :Leaf (:at 1604979640281) (:by |rJG4IHzWf) (:text |div)
-                                                      |L $ %{} :Expr (:at 1604979640489) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1604979640831) (:by |rJG4IHzWf) (:text |{})
-                                                      |T $ %{} :Expr (:at 1604979072642) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |D $ %{} :Leaf (:at 1604979074192) (:by |rJG4IHzWf) (:text |comp-code)
-                                                          |T $ %{} :Expr (:at 1625762769430) (:by |rJG4IHzWf)
-                                                            :data $ {}
-                                                              |T $ %{} :Leaf (:at 1658160425929) (:by |rJG4IHzWf) (:text |&cirru-quote:to-list)
-                                                              |X $ %{} :Expr (:at 1658160430911) (:by |rJG4IHzWf)
-                                                                :data $ {}
-                                                                  |T $ %{} :Leaf (:at 1658160430911) (:by |rJG4IHzWf) (:text |:result)
-                                                                  |b $ %{} :Leaf (:at 1658160430911) (:by |rJG4IHzWf) (:text |code-snippet)
-                                                          |j $ %{} :Leaf (:at 1604979076076) (:by |rJG4IHzWf) (:text |syntax)
-        |comp-cirru-ui-switcher $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1603353264317) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1603353265913) (:by |rJG4IHzWf) (:text |defcomp)
-              |j $ %{} :Leaf (:at 1603353264317) (:by |rJG4IHzWf) (:text |comp-cirru-ui-switcher)
-              |r $ %{} :Expr (:at 1603353264317) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1603353264317) (:by |rJG4IHzWf) (:text |state)
-                  |j $ %{} :Leaf (:at 1603353264317) (:by |rJG4IHzWf) (:text |cursor)
-              |v $ %{} :Expr (:at 1603353267038) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1619983919420) (:by |rJG4IHzWf) (:text |div)
-                  |j $ %{} :Expr (:at 1603353268222) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1603353269371) (:by |rJG4IHzWf) (:text |{})
-                      |b $ %{} :Expr (:at 1603353350858) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690476372758) (:by |rJG4IHzWf) (:text |:class-name)
-                          |b $ %{} :Leaf (:at 1690476375705) (:by |rJG4IHzWf) (:text |css-switcher)
-                      |j $ %{} :Expr (:at 1603353281107) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1603353284678) (:by |rJG4IHzWf) (:text |:on-click)
-                          |j $ %{} :Expr (:at 1603353284990) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1603353285207) (:by |rJG4IHzWf) (:text |fn)
-                              |j $ %{} :Expr (:at 1603353285724) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1603353286027) (:by |rJG4IHzWf) (:text |e)
-                                  |j $ %{} :Leaf (:at 1603353286536) (:by |rJG4IHzWf) (:text |d!)
-                              |r $ %{} :Expr (:at 1603353287015) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1603353287515) (:by |rJG4IHzWf) (:text |d!)
-                                  |j $ %{} :Leaf (:at 1603353288943) (:by |rJG4IHzWf) (:text |cursor)
-                                  |r $ %{} :Expr (:at 1603353290168) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1603353291797) (:by |rJG4IHzWf) (:text |update)
-                                      |j $ %{} :Leaf (:at 1603353293305) (:by |rJG4IHzWf) (:text |state)
-                                      |r $ %{} :Leaf (:at 1603353340961) (:by |rJG4IHzWf) (:text |:cirru-ui?)
-                                      |v $ %{} :Leaf (:at 1603353297999) (:by |rJG4IHzWf) (:text |not)
-                  |l $ %{} :Leaf (:at 1619983923160) (:by |rJG4IHzWf) (:text |&)
-                  |n $ %{} :Expr (:at 1604978192208) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1619707352349) (:by |rJG4IHzWf) (:text |->)
-                      |j $ %{} :Expr (:at 1604978196431) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1604978196786) (:by |rJG4IHzWf) (:text |[])
-                          |j $ %{} :Expr (:at 1604978199888) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1604978202289) (:by |rJG4IHzWf) (:text |{})
-                              |j $ %{} :Expr (:at 1604978202675) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1604978214927) (:by |rJG4IHzWf) (:text |:value)
-                                  |j $ %{} :Leaf (:at 1604978218117) (:by |rJG4IHzWf) (:text |:lisp)
-                              |r $ %{} :Expr (:at 1604978220558) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1604978228060) (:by |rJG4IHzWf) (:text |:display)
-                                  |j $ %{} :Leaf (:at 1604978230457) (:by |rJG4IHzWf) (:text "|\"Lisp")
-                          |r $ %{} :Expr (:at 1604978199888) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1604978202289) (:by |rJG4IHzWf) (:text |{})
-                              |j $ %{} :Expr (:at 1604978202675) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1604978214927) (:by |rJG4IHzWf) (:text |:value)
-                                  |j $ %{} :Leaf (:at 1604978241650) (:by |rJG4IHzWf) (:text |:cirru-text)
-                              |r $ %{} :Expr (:at 1604978220558) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1604978228060) (:by |rJG4IHzWf) (:text |:display)
-                                  |j $ %{} :Leaf (:at 1604978331739) (:by |rJG4IHzWf) (:text "|\"CirruText")
-                          |v $ %{} :Expr (:at 1604978199888) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1604978202289) (:by |rJG4IHzWf) (:text |{})
-                              |j $ %{} :Expr (:at 1604978202675) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1604978214927) (:by |rJG4IHzWf) (:text |:value)
-                                  |j $ %{} :Leaf (:at 1604978249001) (:by |rJG4IHzWf) (:text |:cirru)
-                              |r $ %{} :Expr (:at 1604978220558) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1604978228060) (:by |rJG4IHzWf) (:text |:display)
-                                  |j $ %{} :Leaf (:at 1604978251478) (:by |rJG4IHzWf) (:text "|\"Cirru")
-                      |r $ %{} :Expr (:at 1604978256549) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1619983933436) (:by |rJG4IHzWf) (:text |map)
-                          |j $ %{} :Expr (:at 1604978257439) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1604978257669) (:by |rJG4IHzWf) (:text |fn)
-                              |j $ %{} :Expr (:at 1604978258009) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1604978259035) (:by |rJG4IHzWf) (:text |item)
-                              |r $ %{} :Expr (:at 1604978269276) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1604978269892) (:by |rJG4IHzWf) (:text |div)
-                                  |j $ %{} :Expr (:at 1604978270167) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1604978270480) (:by |rJG4IHzWf) (:text |{})
-                                      |j $ %{} :Expr (:at 1604978287752) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1604978288656) (:by |rJG4IHzWf) (:text |:style)
-                                          |j $ %{} :Expr (:at 1604978360641) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |D $ %{} :Leaf (:at 1604978361510) (:by |rJG4IHzWf) (:text |merge)
-                                              |L $ %{} :Expr (:at 1604978361956) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1604978361956) (:by |rJG4IHzWf) (:text |{})
-                                                  |j $ %{} :Expr (:at 1604978361956) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1604978361956) (:by |rJG4IHzWf) (:text |:margin)
-                                                      |j $ %{} :Leaf (:at 1604978361956) (:by |rJG4IHzWf) (:text "|\"0 4px")
-                                              |T $ %{} :Expr (:at 1604978341082) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |D $ %{} :Leaf (:at 1604978341571) (:by |rJG4IHzWf) (:text |if)
-                                                  |L $ %{} :Expr (:at 1604978343498) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1604978342033) (:by |rJG4IHzWf) (:text |=)
-                                                      |j $ %{} :Expr (:at 1604978345038) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |D $ %{} :Leaf (:at 1604978349950) (:by |rJG4IHzWf) (:text |:syntax)
-                                                          |T $ %{} :Leaf (:at 1604978351187) (:by |rJG4IHzWf) (:text |state)
-                                                      |r $ %{} :Expr (:at 1604978353683) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1604978354289) (:by |rJG4IHzWf) (:text |:value)
-                                                          |j $ %{} :Leaf (:at 1604978355334) (:by |rJG4IHzWf) (:text |item)
-                                                  |f $ %{} :Expr (:at 1604978363605) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1604978363990) (:by |rJG4IHzWf) (:text |{})
-                                                      |j $ %{} :Expr (:at 1604978364247) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1604978366389) (:by |rJG4IHzWf) (:text |:color)
-                                                          |j $ %{} :Expr (:at 1604978366585) (:by |rJG4IHzWf)
-                                                            :data $ {}
-                                                              |T $ %{} :Leaf (:at 1604978366907) (:by |rJG4IHzWf) (:text |hsl)
-                                                              |j $ %{} :Leaf (:at 1604978368830) (:by |rJG4IHzWf) (:text |200)
-                                                              |r $ %{} :Leaf (:at 1604978369305) (:by |rJG4IHzWf) (:text |90)
-                                                              |v $ %{} :Leaf (:at 1604979430465) (:by |rJG4IHzWf) (:text |50)
-                                      |r $ %{} :Expr (:at 1604978292708) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1604978294938) (:by |rJG4IHzWf) (:text |:on-click)
-                                          |j $ %{} :Expr (:at 1604978295179) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1604978295434) (:by |rJG4IHzWf) (:text |fn)
-                                              |j $ %{} :Expr (:at 1604978295653) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1604978295911) (:by |rJG4IHzWf) (:text |e)
-                                                  |j $ %{} :Leaf (:at 1604978296624) (:by |rJG4IHzWf) (:text |d!)
-                                              |r $ %{} :Expr (:at 1604978297212) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1604978377992) (:by |rJG4IHzWf) (:text |d!)
-                                                  |b $ %{} :Leaf (:at 1604978379652) (:by |rJG4IHzWf) (:text |cursor)
-                                                  |j $ %{} :Expr (:at 1604978380748) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1604978381569) (:by |rJG4IHzWf) (:text |assoc)
-                                                      |j $ %{} :Leaf (:at 1604978383163) (:by |rJG4IHzWf) (:text |state)
-                                                      |r $ %{} :Leaf (:at 1604978385283) (:by |rJG4IHzWf) (:text |:syntax)
-                                                      |v $ %{} :Expr (:at 1604978391447) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1604978392704) (:by |rJG4IHzWf) (:text |:value)
-                                                          |j $ %{} :Leaf (:at 1604978393175) (:by |rJG4IHzWf) (:text |item)
-                                  |r $ %{} :Expr (:at 1604978272481) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1604978273090) (:by |rJG4IHzWf) (:text |<>)
-                                      |j $ %{} :Expr (:at 1604978273793) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1604978275486) (:by |rJG4IHzWf) (:text |:display)
-                                          |j $ %{} :Leaf (:at 1604978279662) (:by |rJG4IHzWf) (:text |item)
-        |comp-code $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1604978960000) (:by |rJG4IHzWf) (:text |defcomp)
-              |j $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |comp-code)
-              |n $ %{} :Expr (:at 1604978961044) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1604978962329) (:by |rJG4IHzWf) (:text |code)
-                  |j $ %{} :Leaf (:at 1604978973624) (:by |rJG4IHzWf) (:text |syntax)
-              |p $ %{} :Expr (:at 1621704426474) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1621704428199) (:by |rJG4IHzWf) (:text |assert)
-                  |j $ %{} :Leaf (:at 1621704437260) (:by |rJG4IHzWf) (:text "|\"expected code in list")
-                  |r $ %{} :Expr (:at 1621704438502) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1621704439262) (:by |rJG4IHzWf) (:text |list?)
-                      |j $ %{} :Leaf (:at 1621704440649) (:by |rJG4IHzWf) (:text |code)
-              |r $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |div)
-                  |j $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |{})
-                      |j $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |:style)
-                          |j $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |{})
-                              |v $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |:margin-bottom)
-                                  |j $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |8)
-                  |r $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1646665765117) (:by |rJG4IHzWf) (:text |case-default)
-                      |j $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |syntax)
-                      |n $ %{} :Expr (:at 1646665765947) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1646665765947) (:by |rJG4IHzWf) (:text |str)
-                          |b $ %{} :Leaf (:at 1646665765947) (:by |rJG4IHzWf) (:text "|\"Unknown code: ")
-                          |h $ %{} :Leaf (:at 1646665765947) (:by |rJG4IHzWf) (:text |syntax)
-                      |r $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |:cirru)
-                          |j $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |div)
-                              |j $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |{})
-                                  |j $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1692120876958) (:by |rJG4IHzWf) (:text |:class-name)
-                                      |b $ %{} :Leaf (:at 1692120883467) (:by |rJG4IHzWf) (:text |css-theme-container)
-                              |r $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |render-expr)
-                                  |j $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |code)
-                      |v $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |:cirru-text)
-                          |n $ %{} :Expr (:at 1704536519188) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1704536525050) (:by |rJG4IHzWf) (:text |comp-cirru-snippet)
-                              |b $ %{} :Expr (:at 1704536677356) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |D $ %{} :Leaf (:at 1704536679065) (:by |rJG4IHzWf) (:text |trim)
-                                  |T $ %{} :Expr (:at 1704536541183) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1704536541183) (:by |rJG4IHzWf) (:text |format-cirru)
-                                      |b $ %{} :Expr (:at 1704536541183) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1704536541183) (:by |rJG4IHzWf) (:text |[])
-                                          |b $ %{} :Leaf (:at 1704536541183) (:by |rJG4IHzWf) (:text |code)
-                                      |h $ %{} :Leaf (:at 1704536541183) (:by |rJG4IHzWf) (:text |true)
-                      |x $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |:lisp)
-                          |j $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1704536715695) (:by |rJG4IHzWf) (:text |comp-cirru-snippet)
-                              |j $ %{} :Expr (:at 1604978958075) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |lisp-style)
-                                  |j $ %{} :Leaf (:at 1604978958075) (:by |rJG4IHzWf) (:text |code)
-        |comp-container $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1499755354983) (:by nil)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |defcomp)
-              |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |comp-container)
-              |r $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1507461830530) (:by |root) (:text |reel)
-              |v $ %{} :Expr (:at 1507461832154) (:by |root)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1507461833421) (:by |root) (:text |let)
-                  |L $ %{} :Expr (:at 1507461834351) (:by |root)
-                    :data $ {}
-                      |T $ %{} :Expr (:at 1507461834650) (:by |root)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1507461835738) (:by |root) (:text |store)
-                          |j $ %{} :Expr (:at 1507461836110) (:by |root)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1507461837276) (:by |root) (:text |:store)
-                              |j $ %{} :Leaf (:at 1507461838285) (:by |root) (:text |reel)
-                      |j $ %{} :Expr (:at 1509727104820) (:by |root)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1509727105928) (:by |root) (:text |states)
-                          |j $ %{} :Expr (:at 1509727106316) (:by |root)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1509727107223) (:by |root) (:text |:states)
-                              |j $ %{} :Leaf (:at 1509727108033) (:by |root) (:text |store)
-                      |n $ %{} :Expr (:at 1584780921790) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1584780923771) (:by |rJG4IHzWf) (:text |cursor)
-                          |j $ %{} :Expr (:at 1584780991636) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |D $ %{} :Leaf (:at 1610954643038) (:by |rJG4IHzWf) (:text |either)
-                              |T $ %{} :Expr (:at 1584780923944) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1584780925829) (:by |rJG4IHzWf) (:text |:cursor)
-                                  |j $ %{} :Leaf (:at 1584780926681) (:by |rJG4IHzWf) (:text |states)
-                              |j $ %{} :Expr (:at 1584780993270) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1584780994497) (:by |rJG4IHzWf) (:text |[])
-                      |r $ %{} :Expr (:at 1584780887905) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1584780889620) (:by |rJG4IHzWf) (:text |state)
-                          |j $ %{} :Expr (:at 1584780889933) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1610954640683) (:by |rJG4IHzWf) (:text |either)
-                              |j $ %{} :Expr (:at 1584780894090) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1584780894689) (:by |rJG4IHzWf) (:text |:data)
-                                  |j $ %{} :Leaf (:at 1584780900314) (:by |rJG4IHzWf) (:text |states)
-                              |r $ %{} :Expr (:at 1584780901014) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1584780901408) (:by |rJG4IHzWf) (:text |{})
-                                  |j $ %{} :Expr (:at 1584780901741) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1603121145959) (:by |rJG4IHzWf) (:text |:query)
-                                      |j $ %{} :Expr (:at 1626769070787) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1626769072728) (:by |rJG4IHzWf) (:text |get-query!)
-                                  |r $ %{} :Expr (:at 1603122253205) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1603122265288) (:by |rJG4IHzWf) (:text |:selected-tags)
-                                      |j $ %{} :Expr (:at 1603122265907) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1603122266980) (:by |rJG4IHzWf) (:text |#{})
-                                  |w $ %{} :Expr (:at 1604977616603) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1604977619219) (:by |rJG4IHzWf) (:text |:syntax)
-                                      |j $ %{} :Leaf (:at 1692121003514) (:by |rJG4IHzWf) (:text |:cirru)
-                                  |x $ %{} :Expr (:at 1603363334684) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1603363336121) (:by |rJG4IHzWf) (:text |:wip?)
-                                      |j $ %{} :Leaf (:at 1603363339355) (:by |rJG4IHzWf) (:text |false)
-                      |y $ %{} :Expr (:at 1603122994280) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1603122997808) (:by |rJG4IHzWf) (:text |visible-apis)
-                          |b $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |->)
-                              |b $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |apis-data)
-                              |h $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |filter)
-                                  |b $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |fn)
-                                      |b $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |info)
-                                      |h $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |and)
-                                          |b $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |if)
-                                              |b $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |:wip?)
-                                                  |b $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |state)
-                                              |h $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |:wip?)
-                                                  |b $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |info)
-                                              |l $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |true)
-                                          |h $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |or)
-                                              |b $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |empty?)
-                                                  |b $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |:selected-tags)
-                                                      |b $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |state)
-                                              |h $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |->)
-                                                  |b $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |:selected-tags)
-                                                      |b $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |state)
-                                                  |h $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |every?)
-                                                      |b $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |fn)
-                                                          |b $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                                            :data $ {}
-                                                              |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |x)
-                                                          |h $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                                            :data $ {}
-                                                              |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |includes?)
-                                                              |b $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                                                :data $ {}
-                                                                  |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |:tags)
-                                                                  |b $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |info)
-                                                              |h $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |x)
-                                          |l $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |includes?)
-                                              |b $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |:name)
-                                                  |b $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |info)
-                                              |h $ %{} :Expr (:at 1690396762206) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |:query)
-                                                  |b $ %{} :Leaf (:at 1690396762206) (:by |rJG4IHzWf) (:text |state)
-                  |T $ %{} :Expr (:at 1499755354983) (:by nil)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |div)
-                      |j $ %{} :Expr (:at 1499755354983) (:by nil)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |{})
-                          |b $ %{} :Expr (:at 1646665602400) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1646665605288) (:by |rJG4IHzWf) (:text |:class-name)
-                              |b $ %{} :Expr (:at 1690475865258) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |D $ %{} :Leaf (:at 1690475868481) (:by |rJG4IHzWf) (:text |str-spaced)
-                                  |T $ %{} :Leaf (:at 1646665609636) (:by |rJG4IHzWf) (:text "|\"calcit-tile")
-                                  |X $ %{} :Leaf (:at 1704536622694) (:by |rJG4IHzWf) (:text |css/preset)
-                                  |b $ %{} :Leaf (:at 1690475876315) (:by |rJG4IHzWf) (:text |css/global)
-                                  |h $ %{} :Leaf (:at 1690475879643) (:by |rJG4IHzWf) (:text |css/fullscreen)
-                                  |l $ %{} :Leaf (:at 1690475881899) (:by |rJG4IHzWf) (:text |css/column)
-                          |j $ %{} :Expr (:at 1499755354983) (:by nil)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:style)
-                              |j $ %{} :Expr (:at 1603121393557) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1603121394667) (:by |rJG4IHzWf) (:text |{})
-                                  |r $ %{} :Expr (:at 1603121451691) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1603121451691) (:by |rJG4IHzWf) (:text |:background-color)
-                                      |j $ %{} :Expr (:at 1603121453226) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1603121453670) (:by |rJG4IHzWf) (:text |hsl)
-                                          |j $ %{} :Leaf (:at 1603121454401) (:by |rJG4IHzWf) (:text |0)
-                                          |r $ %{} :Leaf (:at 1603121454734) (:by |rJG4IHzWf) (:text |0)
-                                          |v $ %{} :Leaf (:at 1646665902912) (:by |rJG4IHzWf) (:text |100)
-                      |v $ %{} :Expr (:at 1499755354983) (:by nil)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |div)
-                          |f $ %{} :Expr (:at 1512359526483) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1512359526843) (:by |rJG4IHzWf) (:text |{})
-                              |j $ %{} :Expr (:at 1535563521753) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690475898907) (:by |rJG4IHzWf) (:text |:class-name)
-                                  |j $ %{} :Expr (:at 1603121416304) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |D $ %{} :Leaf (:at 1690475904343) (:by |rJG4IHzWf) (:text |str-spaced)
-                                      |T $ %{} :Leaf (:at 1690476217415) (:by |rJG4IHzWf) (:text |css/column)
-                                      |b $ %{} :Leaf (:at 1690475908528) (:by |rJG4IHzWf) (:text |css-nav)
-                          |fT $ %{} :Expr (:at 1637252361870) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |D $ %{} :Leaf (:at 1637252362456) (:by |rJG4IHzWf) (:text |div)
-                              |L $ %{} :Expr (:at 1637252362681) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1637252362968) (:by |rJG4IHzWf) (:text |{})
-                                  |j $ %{} :Expr (:at 1637252363234) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1690475925225) (:by |rJG4IHzWf) (:text |:class-name)
-                                      |j $ %{} :Leaf (:at 1690475926984) (:by |rJG4IHzWf) (:text |css/row-parted)
-                              |T $ %{} :Expr (:at 1637252453224) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |D $ %{} :Leaf (:at 1637252454413) (:by |rJG4IHzWf) (:text |div)
-                                  |L $ %{} :Expr (:at 1637252454671) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1637252454986) (:by |rJG4IHzWf) (:text |{})
-                                      |j $ %{} :Expr (:at 1637252455233) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1690475929615) (:by |rJG4IHzWf) (:text |:class-name)
-                                          |j $ %{} :Leaf (:at 1690475931317) (:by |rJG4IHzWf) (:text |css/row-middle)
-                                  |P $ %{} :Expr (:at 1637252518113) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1637252518113) (:by |rJG4IHzWf) (:text |a)
-                                      |j $ %{} :Expr (:at 1637252518113) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1637252518113) (:by |rJG4IHzWf) (:text |{})
-                                          |j $ %{} :Expr (:at 1637252518113) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1637252518113) (:by |rJG4IHzWf) (:text |:inner-text)
-                                              |j $ %{} :Leaf (:at 1637252522201) (:by |rJG4IHzWf) (:text "|\"Calcit")
-                                          |r $ %{} :Expr (:at 1637252518113) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1637252518113) (:by |rJG4IHzWf) (:text |:target)
-                                              |j $ %{} :Leaf (:at 1637252518113) (:by |rJG4IHzWf) (:text "|\"_blank")
-                                          |v $ %{} :Expr (:at 1637252518113) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1637252518113) (:by |rJG4IHzWf) (:text |:href)
-                                              |j $ %{} :Leaf (:at 1637252528550) (:by |rJG4IHzWf) (:text "|\"http://calcit-lang.org/")
-                                          |x $ %{} :Expr (:at 1637252545288) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1690475941252) (:by |rJG4IHzWf) (:text |:class-name)
-                                              |b $ %{} :Leaf (:at 1690475945409) (:by |rJG4IHzWf) (:text |css-logo)
-                                  |T $ %{} :Expr (:at 1704536967894) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1704536967894) (:by |rJG4IHzWf) (:text |=<)
-                                      |b $ %{} :Leaf (:at 1704536973129) (:by |rJG4IHzWf) (:text |16)
-                                      |h $ %{} :Leaf (:at 1704536967894) (:by |rJG4IHzWf) (:text |nil)
-                                  |Y $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |div)
-                                      |b $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |{})
-                                          |b $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |:class-name)
-                                              |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |css/row-middle)
-                                      |h $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |input)
-                                          |b $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |{})
-                                              |b $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |:class-name)
-                                                  |b $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |str-spaced)
-                                                      |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |css/input)
-                                                      |h $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |css/font-code!)
-                                              |h $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |:value)
-                                                  |b $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |:query)
-                                                      |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |state)
-                                              |l $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |:placeholder)
-                                                  |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text "|\"search")
-                                              |o $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |:autofocus)
-                                                  |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |true)
-                                              |q $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |:on-input)
-                                                  |b $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |fn)
-                                                      |b $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |e)
-                                                          |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |d!)
-                                                      |h $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |d!)
-                                                          |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |cursor)
-                                                          |h $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                            :data $ {}
-                                                              |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |assoc)
-                                                              |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |state)
-                                                              |h $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |:query)
-                                                              |l $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                                :data $ {}
-                                                                  |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |:value)
-                                                                  |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |e)
-                                      |l $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |=<)
-                                          |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |8)
-                                          |h $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |nil)
-                                      |o $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |<>)
-                                          |b $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |str)
-                                              |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text "|\"has ")
-                                              |h $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |count)
-                                                  |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |visible-apis)
-                                              |l $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text "|\" entries.")
-                                          |h $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |{})
-                                              |b $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |:font-family)
-                                                  |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |ui/font-fancy)
-                                              |h $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |:color)
-                                                  |b $ %{} :Expr (:at 1704536938428) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |hsl)
-                                                      |b $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |0)
-                                                      |h $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |0)
-                                                      |l $ %{} :Leaf (:at 1704536938428) (:by |rJG4IHzWf) (:text |70)
-                                  |b $ %{} :Expr (:at 1704536963164) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1704536964204) (:by |rJG4IHzWf) (:text |=<)
-                                      |b $ %{} :Leaf (:at 1704536964596) (:by |rJG4IHzWf) (:text |8)
-                                      |h $ %{} :Leaf (:at 1704536965107) (:by |rJG4IHzWf) (:text |nil)
-                                  |e $ %{} :Expr (:at 1704536959037) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |div)
-                                      |b $ %{} :Expr (:at 1704536959037) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |{})
-                                          |b $ %{} :Expr (:at 1704536959037) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |:class-name)
-                                              |b $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |css/row-middle)
-                                      |h $ %{} :Expr (:at 1704536959037) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |memof1-call)
-                                          |b $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |comp-cirru-ui-switcher)
-                                          |h $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |state)
-                                          |l $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |cursor)
-                                      |l $ %{} :Expr (:at 1704536959037) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |=<)
-                                          |b $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |12)
-                                          |h $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |nil)
-                                      |o $ %{} :Expr (:at 1704536959037) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |memof1-call)
-                                          |b $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |comp-wip-switcher)
-                                          |h $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |state)
-                                          |l $ %{} :Leaf (:at 1704536959037) (:by |rJG4IHzWf) (:text |cursor)
-                              |j $ %{} :Expr (:at 1704536892501) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |D $ %{} :Leaf (:at 1704536893081) (:by |rJG4IHzWf) (:text |div)
-                                  |L $ %{} :Expr (:at 1704536893356) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1704536893634) (:by |rJG4IHzWf) (:text |{})
-                                      |b $ %{} :Expr (:at 1704536905268) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1704536907825) (:by |rJG4IHzWf) (:text |:class-name)
-                                          |b $ %{} :Leaf (:at 1704536912676) (:by |rJG4IHzWf) (:text |css/row-middle)
-                                  |P $ %{} :Expr (:at 1704536897838) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1704536897838) (:by |rJG4IHzWf) (:text |memof1-call)
-                                      |b $ %{} :Leaf (:at 1704536897838) (:by |rJG4IHzWf) (:text |comp-tags-list)
-                                      |h $ %{} :Leaf (:at 1704536897838) (:by |rJG4IHzWf) (:text |state)
-                                      |l $ %{} :Leaf (:at 1704536897838) (:by |rJG4IHzWf) (:text |cursor)
-                                  |R $ %{} :Expr (:at 1704536904263) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1704536904263) (:by |rJG4IHzWf) (:text |=<)
-                                      |b $ %{} :Leaf (:at 1704536904263) (:by |rJG4IHzWf) (:text |16)
-                                      |h $ %{} :Leaf (:at 1704536904263) (:by |rJG4IHzWf) (:text |nil)
-                                  |T $ %{} :Expr (:at 1637252367945) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1637252369275) (:by |rJG4IHzWf) (:text |a)
-                                      |j $ %{} :Expr (:at 1637252370008) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1637252370321) (:by |rJG4IHzWf) (:text |{})
-                                          |j $ %{} :Expr (:at 1637252370714) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1637252375965) (:by |rJG4IHzWf) (:text |:inner-text)
-                                              |j $ %{} :Leaf (:at 1637252443762) (:by |rJG4IHzWf) (:text "|\"Try & Play")
-                                          |r $ %{} :Expr (:at 1637252404884) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1637252406152) (:by |rJG4IHzWf) (:text |:target)
-                                              |j $ %{} :Leaf (:at 1637252411581) (:by |rJG4IHzWf) (:text "|\"_blank")
-                                          |v $ %{} :Expr (:at 1637252423792) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1637252425006) (:by |rJG4IHzWf) (:text |:href)
-                                              |j $ %{} :Leaf (:at 1637252426251) (:by |rJG4IHzWf) (:text "|\"http://repo.calcit-lang.org/calcit-wasm-play/")
-                      |vD $ %{} :Expr (:at 1628675530786) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |D $ %{} :Leaf (:at 1628675532642) (:by |rJG4IHzWf) (:text |div)
-                          |L $ %{} :Expr (:at 1628675532998) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1628675533313) (:by |rJG4IHzWf) (:text |{})
-                              |b $ %{} :Expr (:at 1690475999022) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690476000827) (:by |rJG4IHzWf) (:text |:class-name)
-                                  |b $ %{} :Leaf (:at 1690476005941) (:by |rJG4IHzWf) (:text |css/expand)
-                              |j $ %{} :Expr (:at 1628675558395) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1628675561035) (:by |rJG4IHzWf) (:text |:style)
-                                  |j $ %{} :Expr (:at 1628675561378) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1628675561703) (:by |rJG4IHzWf) (:text |{})
-                                      |j $ %{} :Expr (:at 1628675562069) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1628675564352) (:by |rJG4IHzWf) (:text |:background-color)
-                                          |j $ %{} :Expr (:at 1646665651014) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1646665651014) (:by |rJG4IHzWf) (:text |hsl)
-                                              |b $ %{} :Leaf (:at 1646665651014) (:by |rJG4IHzWf) (:text |0)
-                                              |h $ %{} :Leaf (:at 1646665651014) (:by |rJG4IHzWf) (:text |0)
-                                              |l $ %{} :Leaf (:at 1646665651014) (:by |rJG4IHzWf) (:text |100)
-                                              |o $ %{} :Leaf (:at 1646665651014) (:by |rJG4IHzWf) (:text |0.6)
-                          |j $ %{} :Expr (:at 1628675546161) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1628675549636) (:by |rJG4IHzWf) (:text |=<)
-                              |j $ %{} :Leaf (:at 1628675550675) (:by |rJG4IHzWf) (:text |nil)
-                              |r $ %{} :Leaf (:at 1628675550961) (:by |rJG4IHzWf) (:text |8)
-                          |r $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |list->)
-                              |j $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |{})
-                                  |j $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1690397882923) (:by |rJG4IHzWf) (:text |:class-name)
-                                      |b $ %{} :Expr (:at 1690397883203) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1690397886324) (:by |rJG4IHzWf) (:text |str-spaced)
-                                          |b $ %{} :Leaf (:at 1690397888739) (:by |rJG4IHzWf) (:text |css/expand)
-                                          |h $ %{} :Leaf (:at 1690397891826) (:by |rJG4IHzWf) (:text |css-list)
-                              |r $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |->)
-                                  |j $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |visible-apis)
-                                  |r $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |sort)
-                                      |j $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |fn)
-                                          |j $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |a)
-                                              |j $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |b)
-                                          |r $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |&str:compare)
-                                              |j $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |:name)
-                                                  |j $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |a)
-                                              |r $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |:name)
-                                                  |j $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |b)
-                                  |v $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |map)
-                                      |j $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |fn)
-                                          |j $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |info)
-                                          |r $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |[])
-                                              |j $ %{} :Expr (:at 1690397398118) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |D $ %{} :Leaf (:at 1690397398885) (:by |rJG4IHzWf) (:text |str)
-                                                  |L $ %{} :Expr (:at 1690397400054) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1690397404143) (:by |rJG4IHzWf) (:text |:source)
-                                                      |b $ %{} :Leaf (:at 1690397404698) (:by |rJG4IHzWf) (:text |info)
-                                                  |T $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |:name)
-                                                      |j $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |info)
-                                              |r $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1650965466957) (:by |rJG4IHzWf) (:text |memof1-call-by)
-                                                  |b $ %{} :Leaf (:at 1650965468169) (:by |rJG4IHzWf) (:text |info)
-                                                  |j $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |comp-api-entry)
-                                                  |r $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |info)
-                                                  |v $ %{} :Expr (:at 1628675553621) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |:syntax)
-                                                      |j $ %{} :Leaf (:at 1628675553621) (:by |rJG4IHzWf) (:text |state)
-                          |v $ %{} :Expr (:at 1628676230195) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1628676233776) (:by |rJG4IHzWf) (:text |=<)
-                              |j $ %{} :Leaf (:at 1628676236418) (:by |rJG4IHzWf) (:text |nil)
-                              |r $ %{} :Leaf (:at 1628676247314) (:by |rJG4IHzWf) (:text |400)
-                      |x $ %{} :Expr (:at 1521954055333) (:by |root)
-                        :data $ {}
-                          |D $ %{} :Leaf (:at 1521954057510) (:by |root) (:text |when)
-                          |L $ %{} :Leaf (:at 1521954059290) (:by |root) (:text |dev?)
-                          |T $ %{} :Expr (:at 1507461809635) (:by |root)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1507461815046) (:by |root) (:text |comp-reel)
-                              |b $ %{} :Expr (:at 1584780610581) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |D $ %{} :Leaf (:at 1584780611347) (:by |rJG4IHzWf) (:text |>>)
-                                  |T $ %{} :Leaf (:at 1509727101297) (:by |root) (:text |states)
-                                  |j $ %{} :Leaf (:at 1584780613268) (:by |rJG4IHzWf) (:text |:reel)
-                              |j $ %{} :Leaf (:at 1507461840459) (:by |root) (:text |reel)
-                              |r $ %{} :Expr (:at 1507461840980) (:by |root)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1507461841342) (:by |root) (:text |{})
-        |comp-method-targets $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1622633395234) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1622633405214) (:by |rJG4IHzWf) (:text |defcomp)
-              |j $ %{} :Leaf (:at 1622633395234) (:by |rJG4IHzWf) (:text |comp-method-targets)
-              |r $ %{} :Expr (:at 1622633395234) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1622633395234) (:by |rJG4IHzWf) (:text |state)
-                  |j $ %{} :Leaf (:at 1622633395234) (:by |rJG4IHzWf) (:text |cursor)
-              |v $ %{} :Expr (:at 1622633647308) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1622633648012) (:by |rJG4IHzWf) (:text |div)
-                  |L $ %{} :Expr (:at 1622633648226) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1622633648568) (:by |rJG4IHzWf) (:text |{})
-                      |j $ %{} :Expr (:at 1622633659934) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1622633661887) (:by |rJG4IHzWf) (:text |:style)
-                          |j $ %{} :Expr (:at 1628677526628) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |D $ %{} :Leaf (:at 1628677527636) (:by |rJG4IHzWf) (:text |merge)
-                              |T $ %{} :Leaf (:at 1622633662704) (:by |rJG4IHzWf) (:text |ui/row)
-                              |j $ %{} :Expr (:at 1628677528227) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1628677529682) (:by |rJG4IHzWf) (:text |{})
-                                  |j $ %{} :Expr (:at 1628677530217) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1628677530217) (:by |rJG4IHzWf) (:text |:user-select)
-                                      |j $ %{} :Leaf (:at 1628677530217) (:by |rJG4IHzWf) (:text |:none)
-                  |P $ %{} :Expr (:at 1622633650369) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1622633653523) (:by |rJG4IHzWf) (:text |<>)
-                      |j $ %{} :Leaf (:at 1622633667642) (:by |rJG4IHzWf) (:text "|\"Methods:")
-                      |r $ %{} :Expr (:at 1628676444799) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |D $ %{} :Leaf (:at 1628676445558) (:by |rJG4IHzWf) (:text |{})
-                          |T $ %{} :Expr (:at 1628676443818) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1628676443818) (:by |rJG4IHzWf) (:text |:font-family)
-                              |j $ %{} :Leaf (:at 1628676443818) (:by |rJG4IHzWf) (:text |ui/font-fancy)
-                  |T $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |div)
-                      |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |{})
-                      |r $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |&)
-                      |v $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |->)
-                          |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |[])
-                              |b $ %{} :Leaf (:at 1622633439475) (:by |rJG4IHzWf) (:text |nil)
-                              |f $ %{} :Leaf (:at 1629457954263) (:by |rJG4IHzWf) (:text |:internals)
-                              |j $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:list)
-                              |r $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:map)
-                              |v $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:number)
-                              |x $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:string)
-                              |y $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:set)
-                              |yr $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:record)
-                              |yt $ %{} :Leaf (:at 1629457942284) (:by |rJG4IHzWf) (:text |:nil)
-                              |yu $ %{} :Leaf (:at 1629457943672) (:by |rJG4IHzWf) (:text |:fn)
-                          |r $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |map)
-                              |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |fn)
-                                  |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1622633461393) (:by |rJG4IHzWf) (:text |target)
-                                  |r $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |div)
-                                      |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |{})
-                                          |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:style)
-                                              |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |merge)
-                                                  |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |{})
-                                                      |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:display)
-                                                          |j $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:inline-block)
-                                                      |r $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:background-color)
-                                                          |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                            :data $ {}
-                                                              |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |hsl)
-                                                              |j $ %{} :Leaf (:at 1622633567321) (:by |rJG4IHzWf) (:text |150)
-                                                              |r $ %{} :Leaf (:at 1622633561842) (:by |rJG4IHzWf) (:text |50)
-                                                              |v $ %{} :Leaf (:at 1622633572642) (:by |rJG4IHzWf) (:text |85)
-                                                      |v $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:margin)
-                                                          |j $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text "|\"4px 4px")
-                                                      |x $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:padding)
-                                                          |j $ %{} :Leaf (:at 1622633579829) (:by |rJG4IHzWf) (:text "|\"0 8px")
-                                                      |y $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:color)
-                                                          |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                            :data $ {}
-                                                              |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |hsl)
-                                                              |j $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |0)
-                                                              |r $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |0)
-                                                              |v $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |100)
-                                                      |yT $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:border-radius)
-                                                          |j $ %{} :Leaf (:at 1622633583079) (:by |rJG4IHzWf) (:text "|\"2px")
-                                                      |yj $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:cursor)
-                                                          |j $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:pointer)
-                                                      |yr $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:line-height)
-                                                          |j $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text "|\"22px")
-                                                  |r $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |if)
-                                                      |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1622633476076) (:by |rJG4IHzWf) (:text |=)
-                                                          |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                            :data $ {}
-                                                              |T $ %{} :Leaf (:at 1622633472820) (:by |rJG4IHzWf) (:text |:method-target)
-                                                              |j $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |state)
-                                                          |r $ %{} :Leaf (:at 1622633474497) (:by |rJG4IHzWf) (:text |target)
-                                                      |r $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |{})
-                                                          |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                            :data $ {}
-                                                              |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:background-color)
-                                                              |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                                :data $ {}
-                                                                  |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |hsl)
-                                                                  |j $ %{} :Leaf (:at 1622633594571) (:by |rJG4IHzWf) (:text |160)
-                                                                  |r $ %{} :Leaf (:at 1622633598589) (:by |rJG4IHzWf) (:text |40)
-                                                                  |v $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |60)
-                                          |r $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |:on-click)
-                                              |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |fn)
-                                                  |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |e)
-                                                      |j $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |d!)
-                                                  |r $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |d!)
-                                                      |j $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |cursor)
-                                                      |r $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |assoc)
-                                                          |j $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |state)
-                                                          |r $ %{} :Leaf (:at 1622633454967) (:by |rJG4IHzWf) (:text |:method-target)
-                                                          |v $ %{} :Leaf (:at 1622633464711) (:by |rJG4IHzWf) (:text |target)
-                                      |r $ %{} :Expr (:at 1622633501484) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |D $ %{} :Leaf (:at 1622633502110) (:by |rJG4IHzWf) (:text |if)
-                                          |L $ %{} :Expr (:at 1622633502628) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1622633503348) (:by |rJG4IHzWf) (:text |some?)
-                                              |j $ %{} :Leaf (:at 1622633503784) (:by |rJG4IHzWf) (:text |target)
-                                          |T $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |<>)
-                                              |j $ %{} :Expr (:at 1622633410552) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1622633410552) (:by |rJG4IHzWf) (:text |turn-string)
-                                                  |j $ %{} :Leaf (:at 1622633480979) (:by |rJG4IHzWf) (:text |target)
-                                          |j $ %{} :Expr (:at 1622633505644) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1622633505954) (:by |rJG4IHzWf) (:text |<>)
-                                              |j $ %{} :Leaf (:at 1622633544400) (:by |rJG4IHzWf) (:text "|\"None")
-                                              |r $ %{} :Expr (:at 1622633520873) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1622633521193) (:by |rJG4IHzWf) (:text |{})
-                                                  |j $ %{} :Expr (:at 1622633521407) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1622633523082) (:by |rJG4IHzWf) (:text |:font-weight)
-                                                      |j $ %{} :Leaf (:at 1622633542073) (:by |rJG4IHzWf) (:text |300)
-                                                  |r $ %{} :Expr (:at 1622633530717) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1622633533113) (:by |rJG4IHzWf) (:text |:font-family)
-                                                      |j $ %{} :Leaf (:at 1622633536806) (:by |rJG4IHzWf) (:text |ui/font-fancy)
-        |comp-tags-list $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1603353261417) (:by |rJG4IHzWf) (:text |defcomp)
-              |j $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |comp-tags-list)
-              |n $ %{} :Expr (:at 1603353199699) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1603353201007) (:by |rJG4IHzWf) (:text |state)
-                  |j $ %{} :Leaf (:at 1603353231016) (:by |rJG4IHzWf) (:text |cursor)
-              |r $ %{} :Expr (:at 1622633671287) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1622633672054) (:by |rJG4IHzWf) (:text |div)
-                  |L $ %{} :Expr (:at 1622633672292) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1622633672664) (:by |rJG4IHzWf) (:text |{})
-                      |j $ %{} :Expr (:at 1622633674092) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690476252099) (:by |rJG4IHzWf) (:text |:class-name)
-                          |j $ %{} :Leaf (:at 1690476255160) (:by |rJG4IHzWf) (:text |css/row)
-                  |P $ %{} :Expr (:at 1622633678581) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1622633680827) (:by |rJG4IHzWf) (:text |<>)
-                      |j $ %{} :Leaf (:at 1690477115626) (:by |rJG4IHzWf) (:text "|\"Tags:")
-                      |r $ %{} :Expr (:at 1628676429385) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1628676430419) (:by |rJG4IHzWf) (:text |{})
-                          |j $ %{} :Expr (:at 1628676430814) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1628676434653) (:by |rJG4IHzWf) (:text |:font-family)
-                              |j $ %{} :Leaf (:at 1628676437689) (:by |rJG4IHzWf) (:text |ui/font-fancy)
-                          |r $ %{} :Expr (:at 1628677510200) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1628677515110) (:by |rJG4IHzWf) (:text |:user-select)
-                              |j $ %{} :Leaf (:at 1628677517355) (:by |rJG4IHzWf) (:text |:none)
-                          |t $ %{} :Expr (:at 1690477132788) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690477135140) (:by |rJG4IHzWf) (:text |:color)
-                              |b $ %{} :Expr (:at 1690477135427) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690477135707) (:by |rJG4IHzWf) (:text |hsl)
-                                  |b $ %{} :Leaf (:at 1690477136114) (:by |rJG4IHzWf) (:text |0)
-                                  |h $ %{} :Leaf (:at 1690477136298) (:by |rJG4IHzWf) (:text |0)
-                                  |l $ %{} :Leaf (:at 1704536789828) (:by |rJG4IHzWf) (:text |85)
-                  |T $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1619983903061) (:by |rJG4IHzWf) (:text |div)
-                      |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |{})
-                      |n $ %{} :Leaf (:at 1619983905248) (:by |rJG4IHzWf) (:text |&)
-                      |r $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1619707385972) (:by |rJG4IHzWf) (:text |->)
-                          |j $ %{} :Expr (:at 1603353223462) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1603353223462) (:by |rJG4IHzWf) (:text |[])
-                              |j $ %{} :Leaf (:at 1603353223462) (:by |rJG4IHzWf) (:text |:list)
-                              |r $ %{} :Leaf (:at 1603353223462) (:by |rJG4IHzWf) (:text |:map)
-                              |v $ %{} :Leaf (:at 1603353223462) (:by |rJG4IHzWf) (:text |:number)
-                              |w $ %{} :Leaf (:at 1603363018265) (:by |rJG4IHzWf) (:text |:string)
-                              |x $ %{} :Leaf (:at 1603353223462) (:by |rJG4IHzWf) (:text |:set)
-                              |y $ %{} :Leaf (:at 1603353223462) (:by |rJG4IHzWf) (:text |:syntax)
-                              |yT $ %{} :Leaf (:at 1603353223462) (:by |rJG4IHzWf) (:text |:macro)
-                              |yj $ %{} :Leaf (:at 1603353223462) (:by |rJG4IHzWf) (:text |:native)
-                          |r $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |map)
-                              |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |fn)
-                                  |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |tag)
-                                  |r $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |div)
-                                      |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |{})
-                                          |b $ %{} :Expr (:at 1690476279343) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1690476282379) (:by |rJG4IHzWf) (:text |:class-name)
-                                              |b $ %{} :Leaf (:at 1690476284194) (:by |rJG4IHzWf) (:text |css-tag)
-                                          |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |:style)
-                                              |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |if)
-                                                  |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1614255229632) (:by |rJG4IHzWf) (:text |includes?)
-                                                      |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |:selected-tags)
-                                                          |j $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |state)
-                                                      |r $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |tag)
-                                                  |r $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |{})
-                                                      |v $ %{} :Expr (:at 1628677478979) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1628677478979) (:by |rJG4IHzWf) (:text |:color)
-                                                          |j $ %{} :Expr (:at 1628677478979) (:by |rJG4IHzWf)
-                                                            :data $ {}
-                                                              |T $ %{} :Leaf (:at 1628677478979) (:by |rJG4IHzWf) (:text |hsl)
-                                                              |j $ %{} :Leaf (:at 1628677478979) (:by |rJG4IHzWf) (:text |280)
-                                                              |r $ %{} :Leaf (:at 1628677478979) (:by |rJG4IHzWf) (:text |80)
-                                                              |v $ %{} :Leaf (:at 1628677483233) (:by |rJG4IHzWf) (:text |50)
-                                          |r $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |:on-click)
-                                              |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                :data $ {}
-                                                  |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |fn)
-                                                  |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |e)
-                                                      |j $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |d!)
-                                                  |v $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                    :data $ {}
-                                                      |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |d!)
-                                                      |j $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |cursor)
-                                                      |r $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                        :data $ {}
-                                                          |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |assoc)
-                                                          |j $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |state)
-                                                          |r $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |:selected-tags)
-                                                          |v $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                            :data $ {}
-                                                              |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |if)
-                                                              |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                                :data $ {}
-                                                                  |T $ %{} :Leaf (:at 1614255233489) (:by |rJG4IHzWf) (:text |includes?)
-                                                                  |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                                    :data $ {}
-                                                                      |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |:selected-tags)
-                                                                      |j $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |state)
-                                                                  |r $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |tag)
-                                                              |r $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                                :data $ {}
-                                                                  |T $ %{} :Leaf (:at 1610957549842) (:by |rJG4IHzWf) (:text |exclude)
-                                                                  |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                                    :data $ {}
-                                                                      |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |:selected-tags)
-                                                                      |j $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |state)
-                                                                  |r $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |tag)
-                                                              |v $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                                :data $ {}
-                                                                  |T $ %{} :Leaf (:at 1610957547669) (:by |rJG4IHzWf) (:text |include)
-                                                                  |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                                                    :data $ {}
-                                                                      |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |:selected-tags)
-                                                                      |j $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |state)
-                                                                  |r $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |tag)
-                                      |r $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                        :data $ {}
-                                          |T $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |<>)
-                                          |j $ %{} :Expr (:at 1603353193859) (:by |rJG4IHzWf)
-                                            :data $ {}
-                                              |T $ %{} :Leaf (:at 1610954536922) (:by |rJG4IHzWf) (:text |turn-string)
-                                              |j $ %{} :Leaf (:at 1603353193859) (:by |rJG4IHzWf) (:text |tag)
-        |comp-wip-switcher $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1603363355911) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1603363357876) (:by |rJG4IHzWf) (:text |defcomp)
-              |j $ %{} :Leaf (:at 1603363355911) (:by |rJG4IHzWf) (:text |comp-wip-switcher)
-              |r $ %{} :Expr (:at 1603363355911) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1603363355911) (:by |rJG4IHzWf) (:text |state)
-                  |j $ %{} :Leaf (:at 1603363355911) (:by |rJG4IHzWf) (:text |cursor)
-              |v $ %{} :Expr (:at 1603363359050) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1603363372084) (:by |rJG4IHzWf) (:text |div)
-                  |j $ %{} :Expr (:at 1603363372833) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1603363373168) (:by |rJG4IHzWf) (:text |{})
-                      |j $ %{} :Expr (:at 1603363383538) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690476408755) (:by |rJG4IHzWf) (:text |:class-name)
-                          |b $ %{} :Leaf (:at 1690476413691) (:by |rJG4IHzWf) (:text |css-wip-switcher)
-                      |r $ %{} :Expr (:at 1603363398005) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1603363400418) (:by |rJG4IHzWf) (:text |:on-click)
-                          |j $ %{} :Expr (:at 1603363400826) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1603363401061) (:by |rJG4IHzWf) (:text |fn)
-                              |j $ %{} :Expr (:at 1603363401271) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1603363401508) (:by |rJG4IHzWf) (:text |e)
-                                  |j $ %{} :Leaf (:at 1603363401941) (:by |rJG4IHzWf) (:text |d!)
-                              |r $ %{} :Expr (:at 1603363402723) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1603363403118) (:by |rJG4IHzWf) (:text |d!)
-                                  |j $ %{} :Leaf (:at 1603363404216) (:by |rJG4IHzWf) (:text |cursor)
-                                  |r $ %{} :Expr (:at 1603363404433) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1603363409030) (:by |rJG4IHzWf) (:text |update)
-                                      |j $ %{} :Leaf (:at 1603363409719) (:by |rJG4IHzWf) (:text |state)
-                                      |r $ %{} :Leaf (:at 1603363412659) (:by |rJG4IHzWf) (:text |:wip?)
-                                      |v $ %{} :Leaf (:at 1603363414042) (:by |rJG4IHzWf) (:text |not)
-                  |r $ %{} :Expr (:at 1603363373692) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1603363374770) (:by |rJG4IHzWf) (:text |<>)
-                      |j $ %{} :Leaf (:at 1603363379384) (:by |rJG4IHzWf) (:text "|\"All/WIP")
-        |css-api-entry $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1690397607719) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1690397609221) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1690397607719) (:by |rJG4IHzWf) (:text |css-api-entry)
-              |h $ %{} :Expr (:at 1690397607719) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1690397620349) (:by |rJG4IHzWf) (:text |{})
-                  |X $ %{} :Expr (:at 1690397680819) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690397681973) (:by |rJG4IHzWf) (:text "|\"&")
-                      |b $ %{} :Expr (:at 1690397683233) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690397683233) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1690397683233) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690397683233) (:by |rJG4IHzWf) (:text |:margin)
-                              |b $ %{} :Leaf (:at 1690397683233) (:by |rJG4IHzWf) (:text "|\"4px")
-                          |h $ %{} :Expr (:at 1690397683233) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690397683233) (:by |rJG4IHzWf) (:text |:padding)
-                              |b $ %{} :Leaf (:at 1692287240031) (:by |rJG4IHzWf) (:text "|\"2px 12px")
-                  |b $ %{} :Expr (:at 1690397623431) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690397627807) (:by |rJG4IHzWf) (:text "|\"&:hover")
-                      |b $ %{} :Expr (:at 1690397628180) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690397628463) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1690397763527) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |D $ %{} :Leaf (:at 1692120817036) (:by |rJG4IHzWf) (:text |;)
-                              |T $ %{} :Leaf (:at 1690397765792) (:by |rJG4IHzWf) (:text |:box-shadow)
-                              |b $ %{} :Expr (:at 1690397776673) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |D $ %{} :Leaf (:at 1690397777345) (:by |rJG4IHzWf) (:text |str)
-                                  |T $ %{} :Leaf (:at 1690397797352) (:by |rJG4IHzWf) (:text "|\"0 1px 1px ")
-                                  |b $ %{} :Expr (:at 1690397778604) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1690397778961) (:by |rJG4IHzWf) (:text |hsl)
-                                      |b $ %{} :Leaf (:at 1690397779496) (:by |rJG4IHzWf) (:text |0)
-                                      |h $ %{} :Leaf (:at 1690397779801) (:by |rJG4IHzWf) (:text |0)
-                                      |l $ %{} :Leaf (:at 1690397780126) (:by |rJG4IHzWf) (:text |0)
-                                      |o $ %{} :Leaf (:at 1690397784444) (:by |rJG4IHzWf) (:text |0.2)
-                          |h $ %{} :Expr (:at 1692120789006) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692120792901) (:by |rJG4IHzWf) (:text |:background-color)
-                              |b $ %{} :Expr (:at 1692120793196) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1692120793501) (:by |rJG4IHzWf) (:text |hsl)
-                                  |b $ %{} :Leaf (:at 1692120793791) (:by |rJG4IHzWf) (:text |0)
-                                  |h $ %{} :Leaf (:at 1692120793977) (:by |rJG4IHzWf) (:text |0)
-                                  |l $ %{} :Leaf (:at 1692120971785) (:by |rJG4IHzWf) (:text |96)
-        |css-api-entry-wip $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1736442131779) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1736442132997) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1736442131779) (:by |rJG4IHzWf) (:text |css-api-entry-wip)
-              |h $ %{} :Expr (:at 1736442135336) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1736442135823) (:by |rJG4IHzWf) (:text |{})
-                  |T $ %{} :Expr (:at 1736442136240) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1736442137962) (:by |rJG4IHzWf) (:text "|\"&")
-                      |T $ %{} :Expr (:at 1736442133744) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1736442133744) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1736442133744) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1736442133744) (:by |rJG4IHzWf) (:text |:color)
-                              |b $ %{} :Expr (:at 1736442133744) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1736442133744) (:by |rJG4IHzWf) (:text |hsl)
-                                  |b $ %{} :Leaf (:at 1736442133744) (:by |rJG4IHzWf) (:text |0)
-                                  |h $ %{} :Leaf (:at 1736442133744) (:by |rJG4IHzWf) (:text |0)
-                                  |l $ %{} :Leaf (:at 1736442133744) (:by |rJG4IHzWf) (:text |80)
-                          |h $ %{} :Expr (:at 1736442133744) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1736442133744) (:by |rJG4IHzWf) (:text |:border-left)
-                              |b $ %{} :Expr (:at 1736442133744) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1736442133744) (:by |rJG4IHzWf) (:text |str)
-                                  |b $ %{} :Leaf (:at 1736442133744) (:by |rJG4IHzWf) (:text "|\"8px solid ")
-                                  |h $ %{} :Expr (:at 1736442133744) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1736442133744) (:by |rJG4IHzWf) (:text |hsl)
-                                      |b $ %{} :Leaf (:at 1736442133744) (:by |rJG4IHzWf) (:text |0)
-                                      |h $ %{} :Leaf (:at 1736442133744) (:by |rJG4IHzWf) (:text |0)
-                                      |l $ %{} :Leaf (:at 1736442133744) (:by |rJG4IHzWf) (:text |90)
-        |css-desc $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1690476057756) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1690476060478) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1690476057756) (:by |rJG4IHzWf) (:text |css-desc)
-              |h $ %{} :Expr (:at 1690476062032) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1690476062594) (:by |rJG4IHzWf) (:text |{})
-                  |T $ %{} :Expr (:at 1690476062996) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1690476064228) (:by |rJG4IHzWf) (:text "|\"&")
-                      |T $ %{} :Expr (:at 1690476061708) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690476061708) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1690476061708) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476061708) (:by |rJG4IHzWf) (:text |:color)
-                              |b $ %{} :Expr (:at 1690476061708) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690476061708) (:by |rJG4IHzWf) (:text |hsl)
-                                  |b $ %{} :Leaf (:at 1690476061708) (:by |rJG4IHzWf) (:text |0)
-                                  |h $ %{} :Leaf (:at 1690476061708) (:by |rJG4IHzWf) (:text |0)
-                                  |l $ %{} :Leaf (:at 1690476061708) (:by |rJG4IHzWf) (:text |70)
-                          |h $ %{} :Expr (:at 1690476061708) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476061708) (:by |rJG4IHzWf) (:text |:padding-left)
-                              |b $ %{} :Leaf (:at 1690476061708) (:by |rJG4IHzWf) (:text |16)
-                          |l $ %{} :Expr (:at 1690476061708) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476061708) (:by |rJG4IHzWf) (:text |:line-height)
-                              |b $ %{} :Leaf (:at 1690476061708) (:by |rJG4IHzWf) (:text "|\"20px")
-        |css-list $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1690397892285) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1690397893731) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1690397892285) (:by |rJG4IHzWf) (:text |css-list)
-              |h $ %{} :Expr (:at 1690397892285) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1690397894742) (:by |rJG4IHzWf) (:text |{})
-                  |b $ %{} :Expr (:at 1690397895442) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690397896013) (:by |rJG4IHzWf) (:text "|\"&")
-                      |b $ %{} :Expr (:at 1690397896399) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690397896694) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1690397896971) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690397899089) (:by |rJG4IHzWf) (:text |:padding)
-                              |b $ %{} :Leaf (:at 1692120951245) (:by |rJG4IHzWf) (:text "|\"0 0px")
-        |css-logo $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1690475945701) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1690475947239) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1690475945701) (:by |rJG4IHzWf) (:text |css-logo)
-              |h $ %{} :Expr (:at 1690475945701) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1690475948395) (:by |rJG4IHzWf) (:text |{})
-                  |b $ %{} :Expr (:at 1690475949058) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690475950127) (:by |rJG4IHzWf) (:text "|\"&")
-                      |b $ %{} :Expr (:at 1690475951090) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1690475951090) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |:font-size)
-                              |b $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |20)
-                          |h $ %{} :Expr (:at 1690475951090) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |:font-family)
-                              |b $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |ui/font-fancy)
-                          |l $ %{} :Expr (:at 1690475951090) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |:text-decoration)
-                              |b $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |:none)
-                          |o $ %{} :Expr (:at 1690475951090) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |:font-weight)
-                              |b $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |:bold)
-                          |q $ %{} :Expr (:at 1690475951090) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |:color)
-                              |b $ %{} :Expr (:at 1690475951090) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |hsl)
-                                  |b $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |200)
-                                  |h $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |100)
-                                  |l $ %{} :Leaf (:at 1690475951090) (:by |rJG4IHzWf) (:text |60)
-        |css-nav $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1690475909420) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1690475910705) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1690475909420) (:by |rJG4IHzWf) (:text |css-nav)
-              |h $ %{} :Expr (:at 1690475912472) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1690475913114) (:by |rJG4IHzWf) (:text |{})
-                  |T $ %{} :Expr (:at 1690475913548) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1690475915021) (:by |rJG4IHzWf) (:text "|\"&")
-                      |T $ %{} :Expr (:at 1690475912074) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1690475912074) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |:background-color)
-                              |b $ %{} :Expr (:at 1690475912074) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |hsl)
-                                  |b $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |0)
-                                  |h $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |0)
-                                  |l $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |100)
-                                  |o $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |0.6)
-                          |h $ %{} :Expr (:at 1690475912074) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |:padding)
-                              |b $ %{} :Leaf (:at 1704537015688) (:by |rJG4IHzWf) (:text "|\"0px 8px 0px")
-                          |l $ %{} :Expr (:at 1690475912074) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |:border-bottom)
-                              |b $ %{} :Expr (:at 1690475912074) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |str)
-                                  |b $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text "|\"1px solid ")
-                                  |h $ %{} :Expr (:at 1690475912074) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |hsl)
-                                      |b $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |0)
-                                      |h $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |0)
-                                      |l $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |90)
-                          |o $ %{} :Expr (:at 1690475912074) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |:box-shadow)
-                              |b $ %{} :Expr (:at 1690475912074) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |str)
-                                  |b $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text "|\"0 0 4px ")
-                                  |h $ %{} :Expr (:at 1690475912074) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |hsl)
-                                      |b $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |0)
-                                      |h $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |0)
-                                      |l $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |0)
-                                      |o $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |0.2)
-                          |q $ %{} :Expr (:at 1690475912074) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |:z-index)
-                              |b $ %{} :Leaf (:at 1690475912074) (:by |rJG4IHzWf) (:text |99)
-        |css-switcher $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1690476376062) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1690476377447) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1690476376062) (:by |rJG4IHzWf) (:text |css-switcher)
-              |h $ %{} :Expr (:at 1690476378381) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1690476379473) (:by |rJG4IHzWf) (:text |{})
-                  |T $ %{} :Expr (:at 1690476379846) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1690476381098) (:by |rJG4IHzWf) (:text "|\"&")
-                      |T $ %{} :Expr (:at 1690476378086) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |merge)
-                          |b $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |ui/row-middle)
-                          |h $ %{} :Expr (:at 1690476378086) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |{})
-                              |b $ %{} :Expr (:at 1690476378086) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |:cursor)
-                                  |b $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |:pointer)
-                              |h $ %{} :Expr (:at 1690476378086) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |:font-family)
-                                  |b $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |ui/font-fancy)
-                              |l $ %{} :Expr (:at 1690476378086) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |:color)
-                                  |b $ %{} :Expr (:at 1690476378086) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |hsl)
-                                      |b $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |200)
-                                      |h $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |80)
-                                      |l $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |80)
-                              |o $ %{} :Expr (:at 1690476378086) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |:font-weight)
-                                  |b $ %{} :Leaf (:at 1690476378086) (:by |rJG4IHzWf) (:text |300)
-        |css-tag $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1690476284640) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1690476286685) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1690476284640) (:by |rJG4IHzWf) (:text |css-tag)
-              |h $ %{} :Expr (:at 1690476287750) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1690476288318) (:by |rJG4IHzWf) (:text |{})
-                  |T $ %{} :Expr (:at 1690476288706) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1690476289843) (:by |rJG4IHzWf) (:text "|\"&")
-                      |T $ %{} :Expr (:at 1690476287425) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1690476287425) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |:display)
-                              |b $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |:inline-block)
-                          |h $ %{} :Expr (:at 1690476287425) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |:margin)
-                              |b $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text "|\"4px 4px")
-                          |l $ %{} :Expr (:at 1690476287425) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |:padding)
-                              |b $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text "|\"0 4px")
-                          |o $ %{} :Expr (:at 1690476287425) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |:color)
-                              |b $ %{} :Expr (:at 1690476287425) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |hsl)
-                                  |b $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |280)
-                                  |h $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |80)
-                                  |l $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |84)
-                          |q $ %{} :Expr (:at 1690476287425) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |:border-radius)
-                              |b $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text "|\"4px")
-                          |s $ %{} :Expr (:at 1690476287425) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |:cursor)
-                              |b $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |:pointer)
-                          |t $ %{} :Expr (:at 1690476287425) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |:line-height)
-                              |b $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text "|\"20px")
-                          |u $ %{} :Expr (:at 1690476287425) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |:user-select)
-                              |b $ %{} :Leaf (:at 1690476287425) (:by |rJG4IHzWf) (:text |:none)
-        |css-theme-container $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1692120883789) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1692120884852) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1692120883789) (:by |rJG4IHzWf) (:text |css-theme-container)
-              |h $ %{} :Expr (:at 1692120886425) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1692120888554) (:by |rJG4IHzWf) (:text |{})
-                  |T $ %{} :Expr (:at 1692120888947) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1692120890272) (:by |rJG4IHzWf) (:text "|\"&")
-                      |T $ %{} :Expr (:at 1692120886173) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1692120886173) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1692120886173) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692120886173) (:by |rJG4IHzWf) (:text |:background-color)
-                              |b $ %{} :Expr (:at 1692120886173) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1692120886173) (:by |rJG4IHzWf) (:text |hsl)
-                                  |b $ %{} :Leaf (:at 1692120886173) (:by |rJG4IHzWf) (:text |300)
-                                  |h $ %{} :Leaf (:at 1692120886173) (:by |rJG4IHzWf) (:text |70)
-                                  |l $ %{} :Leaf (:at 1692120886173) (:by |rJG4IHzWf) (:text |16)
-                          |h $ %{} :Expr (:at 1692120886173) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692120886173) (:by |rJG4IHzWf) (:text |:padding)
-                              |b $ %{} :Leaf (:at 1692120886173) (:by |rJG4IHzWf) (:text "|\"4px 0")
-                          |l $ %{} :Expr (:at 1692120886173) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692120886173) (:by |rJG4IHzWf) (:text |:border-radius)
-                              |b $ %{} :Leaf (:at 1692120886173) (:by |rJG4IHzWf) (:text "|\"4px")
-        |css-wip-switcher $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1690476414036) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1690476415640) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1690476414036) (:by |rJG4IHzWf) (:text |css-wip-switcher)
-              |h $ %{} :Expr (:at 1690476417173) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1690476417678) (:by |rJG4IHzWf) (:text |{})
-                  |T $ %{} :Expr (:at 1690476419328) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1690476420450) (:by |rJG4IHzWf) (:text "|\"&")
-                      |T $ %{} :Expr (:at 1690476416931) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690476416931) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1690476416931) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476416931) (:by |rJG4IHzWf) (:text |:font-family)
-                              |b $ %{} :Leaf (:at 1690476416931) (:by |rJG4IHzWf) (:text |ui/font-fancy)
-                          |h $ %{} :Expr (:at 1690476416931) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476416931) (:by |rJG4IHzWf) (:text |:color)
-                              |b $ %{} :Expr (:at 1690476416931) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690476416931) (:by |rJG4IHzWf) (:text |hsl)
-                                  |b $ %{} :Leaf (:at 1690476416931) (:by |rJG4IHzWf) (:text |200)
-                                  |h $ %{} :Leaf (:at 1690476416931) (:by |rJG4IHzWf) (:text |80)
-                                  |l $ %{} :Leaf (:at 1690476416931) (:by |rJG4IHzWf) (:text |70)
-                          |l $ %{} :Expr (:at 1690476416931) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476416931) (:by |rJG4IHzWf) (:text |:font-weight)
-                              |b $ %{} :Leaf (:at 1690476416931) (:by |rJG4IHzWf) (:text |300)
-                          |o $ %{} :Expr (:at 1690476416931) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690476416931) (:by |rJG4IHzWf) (:text |:cursor)
-                              |b $ %{} :Leaf (:at 1690476416931) (:by |rJG4IHzWf) (:text |:pointer)
-        |get-query! $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1626769073313) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1626769075120) (:by |rJG4IHzWf) (:text |defn)
-              |j $ %{} :Leaf (:at 1626769073313) (:by |rJG4IHzWf) (:text |get-query!)
-              |r $ %{} :Expr (:at 1626769073313) (:by |rJG4IHzWf)
-                :data $ {}
-              |v $ %{} :Expr (:at 1626769076526) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1626769125473) (:by |rJG4IHzWf) (:text |let)
-                  |j $ %{} :Expr (:at 1626769125946) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Expr (:at 1626769126136) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1626769127105) (:by |rJG4IHzWf) (:text |obj)
-                          |j $ %{} :Expr (:at 1626769127598) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1626769127598) (:by |rJG4IHzWf) (:text |new)
-                              |j $ %{} :Leaf (:at 1626769180506) (:by |rJG4IHzWf) (:text |js/URLSearchParams)
-                              |r $ %{} :Leaf (:at 1626769257997) (:by |rJG4IHzWf) (:text |js/location.search)
-                  |t $ %{} :Expr (:at 1626769206707) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1626769207273) (:by |rJG4IHzWf) (:text |if)
-                      |j $ %{} :Expr (:at 1626769208592) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |D $ %{} :Leaf (:at 1626769213020) (:by |rJG4IHzWf) (:text |.!has)
-                          |T $ %{} :Leaf (:at 1626769208482) (:by |rJG4IHzWf) (:text |obj)
-                          |j $ %{} :Leaf (:at 1626769217054) (:by |rJG4IHzWf) (:text "|\"q")
-                      |r $ %{} :Expr (:at 1626769217683) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1626769219866) (:by |rJG4IHzWf) (:text |.!get)
-                          |j $ %{} :Leaf (:at 1626769220399) (:by |rJG4IHzWf) (:text |obj)
-                          |r $ %{} :Leaf (:at 1626769221240) (:by |rJG4IHzWf) (:text "|\"q")
-                      |v $ %{} :Leaf (:at 1626769221996) (:by |rJG4IHzWf) (:text "|\"")
-        |lisp-style $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1603121805988) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1603121805988) (:by |rJG4IHzWf) (:text |defn)
-              |j $ %{} :Leaf (:at 1603270441191) (:by |rJG4IHzWf) (:text |lisp-style)
-              |r $ %{} :Expr (:at 1603121805988) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1603121807879) (:by |rJG4IHzWf) (:text |xs)
-              |v $ %{} :Expr (:at 1610955871668) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1610955872611) (:by |rJG4IHzWf) (:text |cond)
-                  |T $ %{} :Expr (:at 1603121809452) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |j $ %{} :Expr (:at 1603121812621) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1603121812951) (:by |rJG4IHzWf) (:text |string?)
-                          |j $ %{} :Leaf (:at 1603121813407) (:by |rJG4IHzWf) (:text |xs)
-                      |r $ %{} :Expr (:at 1603270446183) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |D $ %{} :Leaf (:at 1603270447263) (:by |rJG4IHzWf) (:text |if)
-                          |L $ %{} :Expr (:at 1610949895065) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1610949896663) (:by |rJG4IHzWf) (:text |or)
-                              |j $ %{} :Expr (:at 1610949897760) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1614255255312) (:by |rJG4IHzWf) (:text |includes?)
-                                  |j $ %{} :Leaf (:at 1610949902281) (:by |rJG4IHzWf) (:text |xs)
-                                  |r $ %{} :Leaf (:at 1610949903108) (:by |rJG4IHzWf) (:text "|\" ")
-                              |r $ %{} :Expr (:at 1610949897760) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1614255257613) (:by |rJG4IHzWf) (:text |includes?)
-                                  |j $ %{} :Leaf (:at 1610949902281) (:by |rJG4IHzWf) (:text |xs)
-                                  |r $ %{} :Leaf (:at 1622634051027) (:by |rJG4IHzWf) (:text |&newline)
-                              |v $ %{} :Expr (:at 1610949897760) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1614255259689) (:by |rJG4IHzWf) (:text |includes?)
-                                  |j $ %{} :Leaf (:at 1610949902281) (:by |rJG4IHzWf) (:text |xs)
-                                  |r $ %{} :Leaf (:at 1610949910668) (:by |rJG4IHzWf) (:text "||\"")
-                          |P $ %{} :Expr (:at 1603270456042) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1603349723145) (:by |rJG4IHzWf) (:text |js/JSON.stringify)
-                              |j $ %{} :Leaf (:at 1603270469067) (:by |rJG4IHzWf) (:text |xs)
-                          |T $ %{} :Leaf (:at 1603121816298) (:by |rJG4IHzWf) (:text |xs)
-                  |j $ %{} :Expr (:at 1610955875165) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Expr (:at 1610956040329) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1610955876270) (:by |rJG4IHzWf) (:text |list?)
-                          |j $ %{} :Leaf (:at 1610956040966) (:by |rJG4IHzWf) (:text |xs)
-                      |T $ %{} :Expr (:at 1610955874194) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1610955874194) (:by |rJG4IHzWf) (:text |str)
-                          |j $ %{} :Leaf (:at 1610955874194) (:by |rJG4IHzWf) (:text "|\"(")
-                          |r $ %{} :Expr (:at 1610955874194) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1619707397625) (:by |rJG4IHzWf) (:text |->)
-                              |j $ %{} :Leaf (:at 1610955874194) (:by |rJG4IHzWf) (:text |xs)
-                              |r $ %{} :Expr (:at 1610955874194) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1610955874194) (:by |rJG4IHzWf) (:text |map)
-                                  |j $ %{} :Leaf (:at 1610955874194) (:by |rJG4IHzWf) (:text |lisp-style)
-                              |v $ %{} :Expr (:at 1610955874194) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1610955874194) (:by |rJG4IHzWf) (:text |join-str)
-                                  |j $ %{} :Leaf (:at 1610955874194) (:by |rJG4IHzWf) (:text "|\" ")
-                          |v $ %{} :Leaf (:at 1610955874194) (:by |rJG4IHzWf) (:text "|\")")
-                  |r $ %{} :Expr (:at 1610955893452) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1610955896412) (:by |rJG4IHzWf) (:text |true)
-                      |j $ %{} :Expr (:at 1610956026577) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |D $ %{} :Leaf (:at 1610956027385) (:by |rJG4IHzWf) (:text |str)
-                          |T $ %{} :Leaf (:at 1610956028396) (:by |rJG4IHzWf) (:text "|\"TODO: ")
-                          |j $ %{} :Expr (:at 1610956029796) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1610956029605) (:by |rJG4IHzWf) (:text |str)
-                              |j $ %{} :Leaf (:at 1610956031004) (:by |rJG4IHzWf) (:text |xs)
-        |stringify-cirru $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1611040642221) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1611040644133) (:by |rJG4IHzWf) (:text |defn)
-              |j $ %{} :Leaf (:at 1611040642221) (:by |rJG4IHzWf) (:text |stringify-cirru)
-              |r $ %{} :Expr (:at 1611040642221) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1611040645324) (:by |rJG4IHzWf) (:text |x)
-              |v $ %{} :Expr (:at 1611040645883) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1611040653283) (:by |rJG4IHzWf) (:text |cond)
-                  |j $ %{} :Expr (:at 1611040653622) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Expr (:at 1611040654118) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1611040655860) (:by |rJG4IHzWf) (:text |string?)
-                          |j $ %{} :Leaf (:at 1611040656278) (:by |rJG4IHzWf) (:text |x)
-                      |j $ %{} :Expr (:at 1611040666158) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1611040667535) (:by |rJG4IHzWf) (:text |escape)
-                          |j $ %{} :Leaf (:at 1611040668950) (:by |rJG4IHzWf) (:text |x)
-                  |r $ %{} :Expr (:at 1611040683419) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Expr (:at 1611040683849) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1611040685069) (:by |rJG4IHzWf) (:text |list?)
-                          |j $ %{} :Leaf (:at 1611040685854) (:by |rJG4IHzWf) (:text |x)
-                      |j $ %{} :Expr (:at 1611040695383) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |D $ %{} :Leaf (:at 1611040696066) (:by |rJG4IHzWf) (:text |str)
-                          |L $ %{} :Leaf (:at 1611040697535) (:by |rJG4IHzWf) (:text "|\"[")
-                          |T $ %{} :Expr (:at 1611040686313) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1611040688999) (:by |rJG4IHzWf) (:text |join-str)
-                              |r $ %{} :Expr (:at 1611040849536) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1611040849536) (:by |rJG4IHzWf) (:text |map)
-                                  |r $ %{} :Leaf (:at 1611040849536) (:by |rJG4IHzWf) (:text |x)
-                                  |v $ %{} :Leaf (:at 1619707297058) (:by |rJG4IHzWf) (:text |stringify-cirru)
-                              |v $ %{} :Leaf (:at 1619707334443) (:by |rJG4IHzWf) (:text "|\",")
-                          |j $ %{} :Leaf (:at 1611040700163) (:by |rJG4IHzWf) (:text "|\"]")
-                  |v $ %{} :Expr (:at 1611040737198) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1611040739005) (:by |rJG4IHzWf) (:text |true)
-                      |j $ %{} :Expr (:at 1611040740499) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1611040741984) (:by |rJG4IHzWf) (:text |raise)
-                          |j $ %{} :Expr (:at 1611040747694) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |D $ %{} :Leaf (:at 1611040749601) (:by |rJG4IHzWf) (:text |str)
-                              |T $ %{} :Leaf (:at 1611040751545) (:by |rJG4IHzWf) (:text "|\"Unknown type: ")
-                              |j $ %{} :Expr (:at 1611040752434) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1611040753437) (:by |rJG4IHzWf) (:text |type-of)
-                                  |j $ %{} :Leaf (:at 1611040754158) (:by |rJG4IHzWf) (:text |x)
-                              |r $ %{} :Leaf (:at 1611040875349) (:by |rJG4IHzWf) (:text |x)
-        |style-api-demo $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1736442205777) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1736442212995) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1736442205777) (:by |rJG4IHzWf) (:text |style-api-demo)
-              |h $ %{} :Expr (:at 1736442207720) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1736442208293) (:by |rJG4IHzWf) (:text |{})
-                  |T $ %{} :Expr (:at 1736442208642) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1736442209778) (:by |rJG4IHzWf) (:text "|\"&")
-                      |T $ %{} :Expr (:at 1736442207125) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1736442207125) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1736442207125) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1736442207125) (:by |rJG4IHzWf) (:text |:margin-left)
-                              |b $ %{} :Leaf (:at 1736442207125) (:by |rJG4IHzWf) (:text |20)
-                          |h $ %{} :Expr (:at 1736442207125) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1736442207125) (:by |rJG4IHzWf) (:text |:flex)
-                              |b $ %{} :Leaf (:at 1736442207125) (:by |rJG4IHzWf) (:text |2)
-        |style-api-result $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1736442073314) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1736442075319) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1736442073314) (:by |rJG4IHzWf) (:text |style-api-result)
-              |h $ %{} :Expr (:at 1736442076088) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1736442076571) (:by |rJG4IHzWf) (:text |{})
-                  |T $ %{} :Expr (:at 1736442076996) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1736442078146) (:by |rJG4IHzWf) (:text "|\"&")
-                      |T $ %{} :Expr (:at 1736442073314) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1736442073314) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1736442073314) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1736442073314) (:by |rJG4IHzWf) (:text |:width)
-                              |b $ %{} :Leaf (:at 1736442073314) (:by |rJG4IHzWf) (:text |40)
-                          |h $ %{} :Expr (:at 1736442073314) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1736442073314) (:by |rJG4IHzWf) (:text |:text-align)
-                              |b $ %{} :Leaf (:at 1736442073314) (:by |rJG4IHzWf) (:text |:center)
-        |style-desc $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1736441958525) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1736441960884) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1736441958525) (:by |rJG4IHzWf) (:text |style-desc)
-              |h $ %{} :Expr (:at 1736441962206) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1736441962866) (:by |rJG4IHzWf) (:text |{})
-                  |T $ %{} :Expr (:at 1736441963398) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1736441964557) (:by |rJG4IHzWf) (:text "|\"&")
-                      |T $ %{} :Expr (:at 1736441961864) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1736441961864) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1736441961864) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1736441961864) (:by |rJG4IHzWf) (:text |:margin-left)
-                              |b $ %{} :Leaf (:at 1736441961864) (:by |rJG4IHzWf) (:text |8)
-                          |h $ %{} :Expr (:at 1736441961864) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1736441961864) (:by |rJG4IHzWf) (:text |:line-height)
-                              |b $ %{} :Leaf (:at 1736441961864) (:by |rJG4IHzWf) (:text "|\"1.5")
-                          |l $ %{} :Expr (:at 1736441961864) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1736441961864) (:by |rJG4IHzWf) (:text |:color)
-                              |b $ %{} :Expr (:at 1736441961864) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1736441961864) (:by |rJG4IHzWf) (:text |hsl)
-                                  |b $ %{} :Leaf (:at 1736441961864) (:by |rJG4IHzWf) (:text |0)
-                                  |h $ %{} :Leaf (:at 1736441961864) (:by |rJG4IHzWf) (:text |0)
-                                  |l $ %{} :Leaf (:at 1736441961864) (:by |rJG4IHzWf) (:text |60)
-        |style-tag $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1692287069811) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1692287071090) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1692287069811) (:by |rJG4IHzWf) (:text |style-tag)
-              |h $ %{} :Expr (:at 1692287069811) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1692287072748) (:by |rJG4IHzWf) (:text |{})
-                  |b $ %{} :Expr (:at 1692287073134) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1692287074326) (:by |rJG4IHzWf) (:text "|\"&")
-                      |b $ %{} :Expr (:at 1692287075174) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1692287075514) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1692287075855) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287078414) (:by |rJG4IHzWf) (:text |:color)
-                              |b $ %{} :Expr (:at 1692287078836) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1692287079168) (:by |rJG4IHzWf) (:text |hsl)
-                                  |b $ %{} :Leaf (:at 1692287079613) (:by |rJG4IHzWf) (:text |0)
-                                  |h $ %{} :Leaf (:at 1692287079972) (:by |rJG4IHzWf) (:text |0)
-                                  |l $ %{} :Leaf (:at 1692287512461) (:by |rJG4IHzWf) (:text |76)
-                          |l $ %{} :Expr (:at 1692287098260) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287102165) (:by |rJG4IHzWf) (:text |:line-height)
-                              |b $ %{} :Leaf (:at 1692287145335) (:by |rJG4IHzWf) (:text "|\"1.2")
-                          |o $ %{} :Expr (:at 1692287112707) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287113926) (:by |rJG4IHzWf) (:text |:padding)
-                              |b $ %{} :Leaf (:at 1692287138588) (:by |rJG4IHzWf) (:text "|\"0 6px")
-                          |q $ %{} :Expr (:at 1692287128206) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287130426) (:by |rJG4IHzWf) (:text |:border-radius)
-                              |b $ %{} :Leaf (:at 1692287135933) (:by |rJG4IHzWf) (:text "|\"6px")
-                          |s $ %{} :Expr (:at 1692287173494) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287178439) (:by |rJG4IHzWf) (:text |:cursor)
-                              |b $ %{} :Leaf (:at 1692287179714) (:by |rJG4IHzWf) (:text |:default)
-                          |t $ %{} :Expr (:at 1692287331478) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287333122) (:by |rJG4IHzWf) (:text |:border)
-                              |b $ %{} :Expr (:at 1692287335203) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1692287337316) (:by |rJG4IHzWf) (:text |str-spaced)
-                                  |b $ %{} :Leaf (:at 1692287344488) (:by |rJG4IHzWf) (:text "|\"1px solid")
-                                  |h $ %{} :Expr (:at 1692287341981) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1692287342469) (:by |rJG4IHzWf) (:text |hsl)
-                                      |b $ %{} :Leaf (:at 1692287346091) (:by |rJG4IHzWf) (:text |0)
-                                      |h $ %{} :Leaf (:at 1692287346344) (:by |rJG4IHzWf) (:text |0)
-                                      |l $ %{} :Leaf (:at 1692287368824) (:by |rJG4IHzWf) (:text |90)
-                          |u $ %{} :Expr (:at 1692287616842) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287619742) (:by |rJG4IHzWf) (:text |:font-size)
-                              |b $ %{} :Leaf (:at 1692287620526) (:by |rJG4IHzWf) (:text |12)
-                  |h $ %{} :Expr (:at 1692287159315) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1692287161773) (:by |rJG4IHzWf) (:text "|\"&:hover")
-                      |b $ %{} :Expr (:at 1692287162450) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1692287163133) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1692287374255) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287374255) (:by |rJG4IHzWf) (:text |:border)
-                              |b $ %{} :Expr (:at 1692287374255) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1692287374255) (:by |rJG4IHzWf) (:text |str-spaced)
-                                  |b $ %{} :Leaf (:at 1692287374255) (:by |rJG4IHzWf) (:text "|\"1px solid")
-                                  |h $ %{} :Expr (:at 1692287374255) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1692287374255) (:by |rJG4IHzWf) (:text |hsl)
-                                      |b $ %{} :Leaf (:at 1692287374255) (:by |rJG4IHzWf) (:text |0)
-                                      |h $ %{} :Leaf (:at 1692287374255) (:by |rJG4IHzWf) (:text |0)
-                                      |l $ %{} :Leaf (:at 1692287376776) (:by |rJG4IHzWf) (:text |80)
-                          |h $ %{} :Expr (:at 1692287398375) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287401524) (:by |rJG4IHzWf) (:text |:background-color)
-                              |b $ %{} :Expr (:at 1692287401850) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1692287402215) (:by |rJG4IHzWf) (:text |hsl)
-                                  |b $ %{} :Leaf (:at 1692287402796) (:by |rJG4IHzWf) (:text |0)
-                                  |h $ %{} :Leaf (:at 1692287403065) (:by |rJG4IHzWf) (:text |0)
-                                  |l $ %{} :Leaf (:at 1692287404115) (:by |rJG4IHzWf) (:text |100)
-                  |l $ %{} :Expr (:at 1692287442930) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1692287447085) (:by |rJG4IHzWf) (:text "|\"&:first-letter")
-                      |b $ %{} :Expr (:at 1692287471901) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1692287473099) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1692287474123) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287475175) (:by |rJG4IHzWf) (:text |:text-transform)
-                              |b $ %{} :Leaf (:at 1692287479418) (:by |rJG4IHzWf) (:text |:uppercase)
-        |style-tags $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1692287011954) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1692287013929) (:by |rJG4IHzWf) (:text |defstyle)
-              |b $ %{} :Leaf (:at 1692287011954) (:by |rJG4IHzWf) (:text |style-tags)
-              |h $ %{} :Expr (:at 1692287011954) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1692287015628) (:by |rJG4IHzWf) (:text |{})
-                  |b $ %{} :Expr (:at 1692287015995) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1692287017075) (:by |rJG4IHzWf) (:text "|\"&")
-                      |b $ %{} :Expr (:at 1692287021038) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1692287021375) (:by |rJG4IHzWf) (:text |{})
-                          |b $ %{} :Expr (:at 1692287023196) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287024646) (:by |rJG4IHzWf) (:text |:padding)
-                              |b $ %{} :Leaf (:at 1692287212248) (:by |rJG4IHzWf) (:text "|\"0 16px")
-                          |h $ %{} :Expr (:at 1692287030376) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1692287031958) (:by |rJG4IHzWf) (:text |:gap)
-                              |b $ %{} :Leaf (:at 1692287753779) (:by |rJG4IHzWf) (:text |6)
-      :ns $ %{} :CodeEntry (:doc |)
-        :code $ %{} :Expr (:at 1499755354983) (:by nil)
-          :data $ {}
-            |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |ns)
-            |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |app.comp.container)
-            |v $ %{} :Expr (:at 1499755354983) (:by nil)
-              :data $ {}
-                |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:require)
-                |j $ %{} :Expr (:at 1499755354983) (:by nil)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1610949416183) (:by |rJG4IHzWf) (:text |respo.util.format)
-                    |r $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:refer)
-                    |v $ %{} :Expr (:at 1499755354983) (:by nil)
-                      :data $ {}
-                        |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |hsl)
-                |r $ %{} :Expr (:at 1499755354983) (:by nil)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1516527080962) (:by |root) (:text |respo-ui.core)
-                    |r $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:as)
-                    |v $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |ui)
-                |t $ %{} :Expr (:at 1690397693174) (:by |rJG4IHzWf)
-                  :data $ {}
-                    |T $ %{} :Leaf (:at 1690397696666) (:by |rJG4IHzWf) (:text |respo-ui.css)
-                    |b $ %{} :Leaf (:at 1690397697537) (:by |rJG4IHzWf) (:text |:as)
-                    |h $ %{} :Leaf (:at 1690397698179) (:by |rJG4IHzWf) (:text |css)
-                |u $ %{} :Expr (:at 1704536529576) (:by |rJG4IHzWf)
-                  :data $ {}
-                    |T $ %{} :Leaf (:at 1704536532312) (:by |rJG4IHzWf) (:text |respo-ui.comp)
-                    |b $ %{} :Leaf (:at 1704536533164) (:by |rJG4IHzWf) (:text |:refer)
-                    |h $ %{} :Expr (:at 1704536533676) (:by |rJG4IHzWf)
-                      :data $ {}
-                        |T $ %{} :Leaf (:at 1704536533922) (:by |rJG4IHzWf) (:text |comp-cirru-snippet)
-                        |b $ %{} :Leaf (:at 1704536703346) (:by |rJG4IHzWf) (:text |comp-snippet)
-                |v $ %{} :Expr (:at 1499755354983) (:by nil)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1540958704705) (:by |root) (:text |respo.core)
-                    |r $ %{} :Leaf (:at 1508946162679) (:by |root) (:text |:refer)
-                    |v $ %{} :Expr (:at 1499755354983) (:by nil)
-                      :data $ {}
-                        |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |defcomp)
-                        |l $ %{} :Leaf (:at 1573355389740) (:by |rJG4IHzWf) (:text |defeffect)
-                        |r $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |<>)
-                        |t $ %{} :Leaf (:at 1584780606618) (:by |rJG4IHzWf) (:text |>>)
-                        |v $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |div)
-                        |x $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |button)
-                        |xT $ %{} :Leaf (:at 1512359490531) (:by |rJG4IHzWf) (:text |textarea)
-                        |y $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |span)
-                        |yT $ %{} :Leaf (:at 1552321107012) (:by |rJG4IHzWf) (:text |input)
-                        |yr $ %{} :Leaf (:at 1604978700418) (:by |rJG4IHzWf) (:text |pre)
-                        |yv $ %{} :Leaf (:at 1619984504175) (:by |rJG4IHzWf) (:text |list->)
-                        |yx $ %{} :Leaf (:at 1637252390744) (:by |rJG4IHzWf) (:text |a)
-                |x $ %{} :Expr (:at 1499755354983) (:by nil)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |respo.comp.space)
-                    |r $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:refer)
-                    |v $ %{} :Expr (:at 1499755354983) (:by nil)
-                      :data $ {}
-                        |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |=<)
-                |y $ %{} :Expr (:at 1507461845717) (:by |root)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1507461855480) (:by |root) (:text |reel.comp.reel)
-                    |r $ %{} :Leaf (:at 1507461856264) (:by |root) (:text |:refer)
-                    |v $ %{} :Expr (:at 1507461856484) (:by |root)
-                      :data $ {}
-                        |j $ %{} :Leaf (:at 1507461858342) (:by |root) (:text |comp-reel)
-                |yT $ %{} :Expr (:at 1519699088529) (:by |root)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1519699092590) (:by |root) (:text |respo-md.comp.md)
-                    |r $ %{} :Leaf (:at 1519699093410) (:by |root) (:text |:refer)
-                    |v $ %{} :Expr (:at 1519699093683) (:by |root)
-                      :data $ {}
-                        |j $ %{} :Leaf (:at 1519699096732) (:by |root) (:text |comp-md)
-                |yj $ %{} :Expr (:at 1521954061310) (:by |root)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1527788377809) (:by |root) (:text |app.config)
-                    |r $ %{} :Leaf (:at 1521954064826) (:by |root) (:text |:refer)
-                    |v $ %{} :Expr (:at 1521954065004) (:by |root)
-                      :data $ {}
-                        |j $ %{} :Leaf (:at 1521954067604) (:by |root) (:text |dev?)
-                |yyT $ %{} :Expr (:at 1603351611308) (:by |rJG4IHzWf)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1603351947552) (:by |rJG4IHzWf) (:text |calcit-theme.comp.expr)
-                    |r $ %{} :Leaf (:at 1603351613199) (:by |rJG4IHzWf) (:text |:refer)
-                    |v $ %{} :Expr (:at 1603351613412) (:by |rJG4IHzWf)
-                      :data $ {}
-                        |j $ %{} :Leaf (:at 1603351950756) (:by |rJG4IHzWf) (:text |render-expr)
-                |yyt $ %{} :Expr (:at 1650965456891) (:by |rJG4IHzWf)
-                  :data $ {}
-                    |T $ %{} :Leaf (:at 1650965458750) (:by |rJG4IHzWf) (:text |memof.once)
-                    |b $ %{} :Leaf (:at 1650965460560) (:by |rJG4IHzWf) (:text |:refer)
-                    |h $ %{} :Expr (:at 1650965460875) (:by |rJG4IHzWf)
-                      :data $ {}
-                        |D $ %{} :Leaf (:at 1704536424574) (:by |rJG4IHzWf) (:text |memof1-call)
-                        |T $ %{} :Leaf (:at 1650965464740) (:by |rJG4IHzWf) (:text |memof1-call-by)
-                |yyv $ %{} :Expr (:at 1629544302190) (:by |rJG4IHzWf)
-                  :data $ {}
-                    |T $ %{} :Leaf (:at 1629544306561) (:by |rJG4IHzWf) (:text |feather.core)
-                    |j $ %{} :Leaf (:at 1629544307193) (:by |rJG4IHzWf) (:text |:refer)
-                    |r $ %{} :Expr (:at 1629544307474) (:by |rJG4IHzWf)
-                      :data $ {}
-                        |T $ %{} :Leaf (:at 1629544308949) (:by |rJG4IHzWf) (:text |comp-i)
-                |z $ %{} :Expr (:at 1690397612605) (:by |rJG4IHzWf)
-                  :data $ {}
-                    |T $ %{} :Leaf (:at 1690397614133) (:by |rJG4IHzWf) (:text |respo.css)
-                    |b $ %{} :Leaf (:at 1690397614847) (:by |rJG4IHzWf) (:text |:refer)
-                    |h $ %{} :Expr (:at 1690397615084) (:by |rJG4IHzWf)
-                      :data $ {}
-                        |T $ %{} :Leaf (:at 1690397616800) (:by |rJG4IHzWf) (:text |defstyle)
-                |zD $ %{} :Expr (:at 1697133143360) (:by |rJG4IHzWf)
-                  :data $ {}
-                    |T $ %{} :Leaf (:at 1697133146136) (:by |rJG4IHzWf) (:text |app.schema)
-                    |b $ %{} :Leaf (:at 1697133147060) (:by |rJG4IHzWf) (:text |:refer)
-                    |h $ %{} :Expr (:at 1697133147394) (:by |rJG4IHzWf)
-                      :data $ {}
-                        |T $ %{} :Leaf (:at 1697133150634) (:by |rJG4IHzWf) (:text |apis-data)
-    |app.config $ %{} :FileEntry
+        |comp-api-entry $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defcomp comp-api-entry (info syntax)
+              div
+                {} $ :class-name
+                  str-spaced css/row css-api-entry $ if (:wip? info) css-api-entry-wip
+                div
+                  {} $ :class-name css/flex
+                  div
+                    {} $ :class-name css/row-middle
+                    <> (:name info) css/font-code
+                    list->
+                      {}
+                        :class-name $ str-spaced css/row-middle style-tags css/font-fancy!
+                        :style $ {} (:margin-top 2)
+                      -> info :tags .to-list $ map
+                        fn (t)
+                          [] t $ <> (turn-string t) style-tag
+                  =< 8 nil
+                  div
+                    {} $ :class-name (str-spaced |md-span css-desc)
+                    comp-md $ either (:desc info) |TODO
+                div
+                  {} $ :class-name (str-spaced css/expand style-api-demo)
+                  , & $ -> (:snippets info)
+                    map $ fn (entry)
+                      let
+                          code-snippet $ if (map? entry) entry
+                            {} $ :code entry
+                          code $ :code code-snippet
+                        div
+                          {} $ :class-name css/row
+                          comp-code (&cirru-quote:to-list code) syntax
+                          if
+                            some? $ :desc code-snippet
+                            ; <> $ :desc code-snippet
+                            div
+                              {} $ :class-name style-desc
+                              comp-md $ :desc code-snippet
+                          if
+                            and (map? code-snippet)
+                              some? $ :result code-snippet
+                            div
+                              {} $ :class-name css/row
+                              div
+                                {} $ :class-name style-api-result
+                                comp-i :arrow-right-circle 16 $ hsl 200 0 50
+                              div ({})
+                                comp-code
+                                  &cirru-quote:to-list $ :result code-snippet
+                                  , syntax
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |comp-cirru-ui-switcher $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defcomp comp-cirru-ui-switcher (state cursor)
+              div
+                {} (:class-name css-switcher)
+                  :on-click $ fn (e d!)
+                    d! cursor $ update state :cirru-ui? not
+                , & $ ->
+                  []
+                    {} (:value :lisp) (:display |Lisp)
+                    {} (:value :cirru-text) (:display |CirruText)
+                    {} (:value :cirru) (:display |Cirru)
+                  map $ fn (item)
+                    div
+                      {}
+                        :style $ merge
+                          {} $ :margin "|0 4px"
+                          if
+                            = (:syntax state) (:value item)
+                            {} $ :color (hsl 200 90 50)
+                        :on-click $ fn (e d!)
+                          d! cursor $ assoc state :syntax (:value item)
+                      <> $ :display item
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |comp-code $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defcomp comp-code (code syntax)
+              assert "|expected code in list" $ list? code
+              div
+                {} $ :style
+                  {} $ :margin-bottom 8
+                case-default syntax (str "|Unknown code: " syntax)
+                  :cirru $ div
+                    {} $ :class-name css-theme-container
+                    render-expr code
+                  :cirru-text $ comp-cirru-snippet
+                    trim $ format-cirru ([] code)
+                  :lisp $ comp-cirru-snippet (lisp-style code)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |comp-container $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defcomp comp-container (reel)
+              let
+                  store $ :store reel
+                  states $ :states store
+                  cursor $ either (:cursor states) ([])
+                  state $ either (:data states)
+                    {}
+                      :query $ get-query!
+                      :selected-tags $ #{}
+                      :syntax :cirru
+                      :wip? false
+                  visible-apis $ -> apis-data
+                    filter $ fn (info)
+                      and
+                        if (:wip? state) (:wip? info) true
+                        or
+                          empty? $ :selected-tags state
+                          -> (:selected-tags state)
+                            every? $ fn (x)
+                              includes? (:tags info) x
+                        includes? (:name info) (:query state)
+                div
+                  {}
+                    :class-name $ str-spaced |calcit-tile css/preset css/global css/fullscreen css/column
+                    :style $ {}
+                      :background-color $ hsl 0 0 100
+                  div
+                    {} $ :class-name (str-spaced css/column css-nav)
+                    div
+                      {} $ :class-name css/row-parted
+                      div
+                        {} $ :class-name css/row-middle
+                        a $ {} (:inner-text |Calcit) (:target |_blank) (:href |http://calcit-lang.org/) (:class-name css-logo)
+                        =< 16 nil
+                        div
+                          {} $ :class-name css/row-middle
+                          input $ {}
+                            :class-name $ str-spaced css/input css/font-code!
+                            :value $ :query state
+                            :placeholder |search
+                            :autofocus true
+                            :on-input $ fn (e d!)
+                              d! cursor $ assoc state :query (:value e)
+                          =< 8 nil
+                          <>
+                            str "|has " (count visible-apis) "| entries."
+                            {} (:font-family ui/font-fancy)
+                              :color $ hsl 0 0 70
+                        =< 8 nil
+                        div
+                          {} $ :class-name css/row-middle
+                          memof1-call comp-cirru-ui-switcher state cursor
+                          =< 12 nil
+                          memof1-call comp-wip-switcher state cursor
+                      div
+                        {} $ :class-name css/row-middle
+                        memof1-call comp-tags-list state cursor
+                        =< 16 nil
+                        a $ {} (:inner-text "|Try & Play") (:target |_blank) (:href |http://repo.calcit-lang.org/calcit-wasm-play/)
+                  div
+                    {} (:class-name css/expand)
+                      :style $ {}
+                        :background-color $ hsl 0 0 100 0.6
+                    =< nil 8
+                    list->
+                      {} $ :class-name (str-spaced css/expand css-list)
+                      -> visible-apis
+                        sort $ fn (a b)
+                          &str:compare (:name a) (:name b)
+                        map $ fn (info)
+                          []
+                            str (:source info) (:name info)
+                            memof1-call-by info comp-api-entry info $ :syntax state
+                    =< nil 400
+                  when dev? $ comp-reel (>> states :reel) reel ({})
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |comp-method-targets $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defcomp comp-method-targets (state cursor)
+              div
+                {} $ :style
+                  merge ui/row $ {} (:user-select :none)
+                <> |Methods: $ {} (:font-family ui/font-fancy)
+                div ({}) & $ -> ([] nil :internals :list :map :number :string :set :record :nil :fn)
+                  map $ fn (target)
+                    div
+                      {}
+                        :style $ merge
+                          {} (:display :inline-block)
+                            :background-color $ hsl 150 50 85
+                            :margin "|4px 4px"
+                            :padding "|0 8px"
+                            :color $ hsl 0 0 100
+                            :border-radius |2px
+                            :cursor :pointer
+                            :line-height |22px
+                          if
+                            = (:method-target state) target
+                            {} $ :background-color (hsl 160 40 60)
+                        :on-click $ fn (e d!)
+                          d! cursor $ assoc state :method-target target
+                      if (some? target)
+                        <> $ turn-string target
+                        <> |None $ {} (:font-weight 300) (:font-family ui/font-fancy)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |comp-tags-list $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defcomp comp-tags-list (state cursor)
+              div
+                {} $ :class-name css/row
+                <> |Tags: $ {} (:font-family ui/font-fancy) (:user-select :none)
+                  :color $ hsl 0 0 85
+                div ({}) & $ -> ([] :list :map :number :string :set :syntax :macro :native)
+                  map $ fn (tag)
+                    div
+                      {} (:class-name css-tag)
+                        :style $ if
+                          includes? (:selected-tags state) tag
+                          {} $ :color (hsl 280 80 50)
+                        :on-click $ fn (e d!)
+                          d! cursor $ assoc state :selected-tags
+                            if
+                              includes? (:selected-tags state) tag
+                              exclude (:selected-tags state) tag
+                              include (:selected-tags state) tag
+                      <> $ turn-string tag
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |comp-wip-switcher $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defcomp comp-wip-switcher (state cursor)
+              div
+                {} (:class-name css-wip-switcher)
+                  :on-click $ fn (e d!)
+                    d! cursor $ update state :wip? not
+                <> |All/WIP
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |css-api-entry $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle css-api-entry $ {}
+              |& $ {} (:margin |4px) (:padding "|2px 12px")
+              |&:hover $ {}
+                ; :box-shadow $ str "|0 1px 1px " (hsl 0 0 0 0.2)
+                :background-color $ hsl 0 0 96
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |css-api-entry-wip $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle css-api-entry-wip $ {}
+              |& $ {}
+                :color $ hsl 0 0 80
+                :border-left $ str "|8px solid " (hsl 0 0 90)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |css-desc $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle css-desc $ {}
+              |& $ {}
+                :color $ hsl 0 0 70
+                :padding-left 16
+                :line-height |20px
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |css-list $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle css-list $ {}
+              |& $ {} (:padding "|0 0px")
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |css-logo $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle css-logo $ {}
+              |& $ {} (:font-size 20) (:font-family ui/font-fancy) (:text-decoration :none) (:font-weight :bold)
+                :color $ hsl 200 100 60
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |css-nav $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle css-nav $ {}
+              |& $ {}
+                :background-color $ hsl 0 0 100 0.6
+                :padding "|0px 8px 0px"
+                :border-bottom $ str "|1px solid " (hsl 0 0 90)
+                :box-shadow $ str "|0 0 4px " (hsl 0 0 0 0.2)
+                :z-index 99
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |css-switcher $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle css-switcher $ {}
+              |& $ merge ui/row-middle
+                {} (:cursor :pointer) (:font-family ui/font-fancy)
+                  :color $ hsl 200 80 80
+                  :font-weight 300
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |css-tag $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle css-tag $ {}
+              |& $ {} (:display :inline-block) (:margin "|4px 4px") (:padding "|0 4px")
+                :color $ hsl 280 80 84
+                :border-radius |4px
+                :cursor :pointer
+                :line-height |20px
+                :user-select :none
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |css-theme-container $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle css-theme-container $ {}
+              |& $ {}
+                :background-color $ hsl 300 70 16
+                :padding "|4px 0"
+                :border-radius |4px
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |css-wip-switcher $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle css-wip-switcher $ {}
+              |& $ {} (:font-family ui/font-fancy)
+                :color $ hsl 200 80 70
+                :font-weight 300
+                :cursor :pointer
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |get-query! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn get-query! () $ let
+                obj $ new js/URLSearchParams js/location.search
+              if (.!has obj |q) (.!get obj |q) |
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |lisp-style $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn lisp-style (xs)
+              cond
+                  string? xs
+                  if
+                    or (includes? xs "| ") (includes? xs &newline) (includes? xs "|\"")
+                    js/JSON.stringify xs
+                    , xs
+                (list? xs)
+                  str "|("
+                    -> xs (map lisp-style) (join-str "| ")
+                    , "|)"
+                true $ str "|TODO: " (str xs)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |stringify-cirru $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn stringify-cirru (x)
+              cond
+                  string? x
+                  escape x
+                (list? x)
+                  str |[
+                    join-str (map x stringify-cirru) |,
+                    , |]
+                true $ raise
+                  str "|Unknown type: " (type-of x) x
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |style-api-demo $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle style-api-demo $ {}
+              |& $ {} (:margin-left 20) (:flex 2)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |style-api-result $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle style-api-result $ {}
+              |& $ {} (:width 40) (:text-align :center)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |style-desc $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle style-desc $ {}
+              |& $ {} (:margin-left 8) (:line-height |1.5)
+                :color $ hsl 0 0 60
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |style-tag $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle style-tag $ {}
+              |& $ {}
+                :color $ hsl 0 0 76
+                :line-height |1.2
+                :padding "|0 6px"
+                :border-radius |6px
+                :cursor :default
+                :border $ str-spaced "|1px solid" (hsl 0 0 90)
+                :font-size 12
+              |&:hover $ {}
+                :border $ str-spaced "|1px solid" (hsl 0 0 80)
+                :background-color $ hsl 0 0 100
+              |&:first-letter $ {} (:text-transform :uppercase)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |style-tags $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstyle style-tags $ {}
+              |& $ {} (:padding "|0 16px") (:gap 6)
+          :examples $ []
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
+        :code $ quote
+          ns app.comp.container $ :require
+            respo.util.format :refer $ hsl
+            respo-ui.core :as ui
+            respo-ui.css :as css
+            respo-ui.comp :refer $ comp-cirru-snippet comp-snippet
+            respo.core :refer $ defcomp defeffect <> >> div button textarea span input pre list-> a
+            respo.comp.space :refer $ =<
+            reel.comp.reel :refer $ comp-reel
+            respo-md.comp.md :refer $ comp-md
+            app.config :refer $ dev?
+            calcit-theme.comp.expr :refer $ render-expr
+            memof.once :refer $ memof1-call memof1-call-by
+            feather.core :refer $ comp-i
+            respo.css :refer $ defstyle
+            app.schema :refer $ apis-data
+    |app.config $ %{} 'FileEntry
       :defs $ {}
-        |dev? $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1544873875614) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1544873875614) (:by |rJG4IHzWf) (:text |def)
-              |j $ %{} :Leaf (:at 1544873875614) (:by |rJG4IHzWf) (:text |dev?)
-              |r $ %{} :Expr (:at 1697135506181) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1697135506647) (:by |rJG4IHzWf) (:text |=)
-                  |L $ %{} :Leaf (:at 1697135508378) (:by |rJG4IHzWf) (:text "|\"dev")
-                  |T $ %{} :Expr (:at 1664705533264) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1664705534987) (:by |rJG4IHzWf) (:text |get-env)
-                      |b $ %{} :Leaf (:at 1664705536279) (:by |rJG4IHzWf) (:text "|\"mode")
-                      |h $ %{} :Leaf (:at 1664705539040) (:by |rJG4IHzWf) (:text "|\"release")
-        |site $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1545933382603) (:by |root)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1518157345496) (:by |root) (:text |def)
-              |j $ %{} :Leaf (:at 1518157327696) (:by |root) (:text |site)
-              |r $ %{} :Expr (:at 1518157327696) (:by |root)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1518157346643) (:by |root) (:text |{})
-                  |r $ %{} :Expr (:at 1527526861413) (:by |root)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1527526864597) (:by |root) (:text |:dev-ui)
-                      |x $ %{} :Leaf (:at 1556700447561) (:by |rJG4IHzWf) (:text "|\"http://localhost:8100/main-fonts.css")
-                  |v $ %{} :Expr (:at 1527526865931) (:by |root)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1527526868617) (:by |root) (:text |:release-ui)
-                      |j $ %{} :Leaf (:at 1556700443008) (:by |rJG4IHzWf) (:text "|\"http://cdn.tiye.me/favored-fonts/main-fonts.css")
-                  |w $ %{} :Expr (:at 1528008960614) (:by |root)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1528008962775) (:by |root) (:text |:cdn-url)
-                      |j $ %{} :Leaf (:at 1528008965359) (:by |root) (:text "|\"http://cdn.tiye.me/calcit-workflow/")
-                  |y $ %{} :Expr (:at 1527868456422) (:by |root)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1527868457305) (:by |root) (:text |:title)
-                      |j $ %{} :Leaf (:at 1603167524702) (:by |rJG4IHzWf) (:text "|\"APIs for calcit-runner")
-                  |yT $ %{} :Expr (:at 1527868457696) (:by |root)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1527868458476) (:by |root) (:text |:icon)
-                      |j $ %{} :Leaf (:at 1603422163889) (:by |rJG4IHzWf) (:text "|\"http://cdn.tiye.me/logo/cirru.png")
-                  |yf $ %{} :Expr (:at 1544956719115) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1544956719115) (:by |rJG4IHzWf) (:text |:storage-key)
-                      |j $ %{} :Leaf (:at 1603167514094) (:by |rJG4IHzWf) (:text "|\"calcit-runner-apis")
-      :ns $ %{} :CodeEntry (:doc |)
-        :code $ %{} :Expr (:at 1527788237503) (:by |root)
-          :data $ {}
-            |T $ %{} :Leaf (:at 1527788237503) (:by |root) (:text |ns)
-            |j $ %{} :Leaf (:at 1527788237503) (:by |root) (:text |app.config)
-    |app.main $ %{} :FileEntry
+        |dev? $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            def dev? $ = |dev (get-env |mode |release)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |site $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            def site $ {} (:dev-ui |http://localhost:8100/main-fonts.css) (:release-ui |http://cdn.tiye.me/favored-fonts/main-fonts.css) (:cdn-url |http://cdn.tiye.me/calcit-workflow/) (:title "|APIs for calcit-runner") (:icon |http://cdn.tiye.me/logo/cirru.png) (:storage-key |calcit-runner-apis)
+          :examples $ []
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
+        :code $ quote (ns app.config)
+    |app.main $ %{} 'FileEntry
       :defs $ {}
-        |*reel $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1499755354983) (:by nil)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1610950021279) (:by |rJG4IHzWf) (:text |defatom)
-              |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |*reel)
-              |r $ %{} :Expr (:at 1507399777531) (:by |root)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1507399778895) (:by |root) (:text |->)
-                  |T $ %{} :Leaf (:at 1507399776350) (:by |root) (:text |reel-schema/reel)
-                  |j $ %{} :Expr (:at 1507399779656) (:by |root)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1507399781682) (:by |root) (:text |assoc)
-                      |j $ %{} :Leaf (:at 1507401405076) (:by |root) (:text |:base)
-                      |r $ %{} :Leaf (:at 1507399787471) (:by |root) (:text |schema/store)
-                  |r $ %{} :Expr (:at 1507399779656) (:by |root)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1507399781682) (:by |root) (:text |assoc)
-                      |j $ %{} :Leaf (:at 1507399793097) (:by |root) (:text |:store)
-                      |r $ %{} :Leaf (:at 1507399787471) (:by |root) (:text |schema/store)
-        |dispatch! $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1499755354983) (:by nil)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |defn)
-              |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |dispatch!)
-              |r $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |op)
-              |t $ %{} :Expr (:at 1547437686766) (:by |root)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1547437687530) (:by |root) (:text |when)
-                  |L $ %{} :Expr (:at 1584874661674) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1584874662518) (:by |rJG4IHzWf) (:text |and)
-                      |T $ %{} :Leaf (:at 1547437691006) (:by |root) (:text |config/dev?)
-                  |T $ %{} :Expr (:at 1518156274050) (:by |root)
-                    :data $ {}
-                      |j $ %{} :Leaf (:at 1690397259142) (:by |rJG4IHzWf) (:text |js/console.log)
-                      |r $ %{} :Leaf (:at 1547437698992) (:by |root) (:text "|\"Dispatch:")
-                      |v $ %{} :Leaf (:at 1518156280471) (:by |root) (:text |op)
-              |v $ %{} :Expr (:at 1584780634192) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |reset!)
-                  |j $ %{} :Leaf (:at 1507399899641) (:by |root) (:text |*reel)
-                  |r $ %{} :Expr (:at 1507399884621) (:by |root)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1507399887573) (:by |root) (:text |reel-updater)
-                      |j $ %{} :Leaf (:at 1507399888500) (:by |root) (:text |updater)
-                      |r $ %{} :Leaf (:at 1507399891576) (:by |root) (:text |@*reel)
-                      |v $ %{} :Leaf (:at 1507399892687) (:by |root) (:text |op)
-        |main! $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1499755354983) (:by nil)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |defn)
-              |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |main!)
-              |r $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-              |s $ %{} :Expr (:at 1690397240784) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1690397241360) (:by |rJG4IHzWf) (:text |if)
-                  |L $ %{} :Leaf (:at 1690397249823) (:by |rJG4IHzWf) (:text |config/dev?)
-                  |T $ %{} :Expr (:at 1619982941704) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1619982955984) (:by |rJG4IHzWf) (:text |load-console-formatter!)
-              |t $ %{} :Expr (:at 1544874433785) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1544874434638) (:by |rJG4IHzWf) (:text |println)
-                  |j $ %{} :Leaf (:at 1544874509800) (:by |rJG4IHzWf) (:text "|\"Running mode:")
-                  |r $ %{} :Expr (:at 1544874440404) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1544874440190) (:by |rJG4IHzWf) (:text |if)
-                      |j $ %{} :Leaf (:at 1544874446442) (:by |rJG4IHzWf) (:text |config/dev?)
-                      |r $ %{} :Leaf (:at 1544874449063) (:by |rJG4IHzWf) (:text "|\"dev")
-                      |v $ %{} :Leaf (:at 1544874452316) (:by |rJG4IHzWf) (:text "|\"release")
-              |v $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |if)
-                  |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |ssr?)
-                  |r $ %{} :Expr (:at 1499755354983) (:by nil)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |render-app!)
-                      |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |realize-ssr!)
-              |x $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |render-app!)
-                  |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |render!)
-              |y $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |add-watch)
-                  |j $ %{} :Leaf (:at 1507399915531) (:by |root) (:text |*reel)
-                  |r $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:changes)
-                  |v $ %{} :Expr (:at 1499755354983) (:by nil)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |fn)
-                      |j $ %{} :Expr (:at 1499755354983) (:by nil)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1612176018403) (:by |rJG4IHzWf) (:text |reel)
-                          |j $ %{} :Leaf (:at 1612176021385) (:by |rJG4IHzWf) (:text |prev-reel)
-                      |r $ %{} :Expr (:at 1499755354983) (:by nil)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |render-app!)
-                          |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |render!)
-              |yD $ %{} :Expr (:at 1507461684494) (:by |root)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1507461739167) (:by |root) (:text |listen-devtools!)
-                  |j $ %{} :Leaf (:at 1507461691211) (:by |root) (:text ||a)
-                  |r $ %{} :Leaf (:at 1507461693919) (:by |root) (:text |dispatch!)
-              |yL $ %{} :Expr (:at 1518157357847) (:by |root)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1610955980179) (:by |rJG4IHzWf) (:text |;)
-                  |T $ %{} :Leaf (:at 1518157450281) (:by |root) (:text |.addEventListener)
-                  |j $ %{} :Leaf (:at 1518157453505) (:by |root) (:text |js/window)
-                  |r $ %{} :Leaf (:at 1518157458163) (:by |root) (:text ||beforeunload)
-                  |v $ %{} :Leaf (:at 1533919515671) (:by |rJG4IHzWf) (:text |persist-storage!)
-              |yN $ %{} :Expr (:at 1533919529874) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1610955977102) (:by |rJG4IHzWf) (:text |;)
-                  |T $ %{} :Leaf (:at 1544956062322) (:by |rJG4IHzWf) (:text |repeat!)
-                  |b $ %{} :Leaf (:at 1544956066171) (:by |rJG4IHzWf) (:text |60)
-                  |j $ %{} :Leaf (:at 1533919535136) (:by |rJG4IHzWf) (:text |persist-storage!)
-              |yP $ %{} :Expr (:at 1518157492640) (:by |root)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1610955974955) (:by |rJG4IHzWf) (:text |;)
-                  |T $ %{} :Leaf (:at 1518157495438) (:by |root) (:text |let)
-                  |j $ %{} :Expr (:at 1518157495644) (:by |root)
-                    :data $ {}
-                      |T $ %{} :Expr (:at 1518157495826) (:by |root)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1518157496930) (:by |root) (:text |raw)
-                          |j $ %{} :Expr (:at 1518157497615) (:by |root)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690396415616) (:by |rJG4IHzWf) (:text |js/localStorage.getItem)
-                              |r $ %{} :Expr (:at 1518157506313) (:by |root)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1544956709260) (:by |rJG4IHzWf) (:text |:storage-key)
-                                  |j $ %{} :Leaf (:at 1527788293499) (:by |root) (:text |config/site)
-                  |r $ %{} :Expr (:at 1518157514334) (:by |root)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1533919640958) (:by |rJG4IHzWf) (:text |when)
-                      |j $ %{} :Expr (:at 1518157515117) (:by |root)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1518157515786) (:by |root) (:text |some?)
-                          |j $ %{} :Leaf (:at 1518157516878) (:by |root) (:text |raw)
-                      |r $ %{} :Expr (:at 1518157521635) (:by |root)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1518157523818) (:by |root) (:text |dispatch!)
-                          |r $ %{} :Expr (:at 1690396418455) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |D $ %{} :Leaf (:at 1690396419037) (:by |rJG4IHzWf) (:text |::)
-                              |L $ %{} :Leaf (:at 1690396419422) (:by |rJG4IHzWf) (:text |:hydrate-storage)
-                              |T $ %{} :Expr (:at 1610955967874) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |D $ %{} :Leaf (:at 1610955973069) (:by |rJG4IHzWf) (:text |extract-cirru-data)
-                                  |T $ %{} :Expr (:at 1518157527987) (:by |root)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1610955966742) (:by |rJG4IHzWf) (:text |js/JSON.parse)
-                                      |j $ %{} :Leaf (:at 1518157531240) (:by |root) (:text |raw)
-              |yT $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |println)
-                  |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text "||App started.")
-        |mount-target $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1499755354983) (:by nil)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |def)
-              |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |mount-target)
-              |r $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-                  |j $ %{} :Leaf (:at 1696239596447) (:by |rJG4IHzWf) (:text |js/document.querySelector)
-                  |r $ %{} :Leaf (:at 1499755354983) (:by |root) (:text ||.app)
-        |persist-storage! $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1533919515671) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1533919517365) (:by |rJG4IHzWf) (:text |defn)
-              |j $ %{} :Leaf (:at 1533919515671) (:by |rJG4IHzWf) (:text |persist-storage!)
-              |r $ %{} :Expr (:at 1533919515671) (:by |rJG4IHzWf)
-                :data $ {}
-              |v $ %{} :Expr (:at 1533919515671) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1610955983714) (:by |rJG4IHzWf) (:text |;)
-                  |T $ %{} :Leaf (:at 1533919515671) (:by |rJG4IHzWf) (:text |.setItem)
-                  |j $ %{} :Leaf (:at 1533919515671) (:by |rJG4IHzWf) (:text |js/localStorage)
-                  |r $ %{} :Expr (:at 1533919515671) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1544956703087) (:by |rJG4IHzWf) (:text |:storage-key)
-                      |j $ %{} :Leaf (:at 1533919515671) (:by |rJG4IHzWf) (:text |config/site)
-                  |v $ %{} :Expr (:at 1610955957287) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1610955960605) (:by |rJG4IHzWf) (:text |js/JSON.stringify)
-                      |T $ %{} :Expr (:at 1533919515671) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1610955956856) (:by |rJG4IHzWf) (:text |to-calcit-data)
-                          |j $ %{} :Expr (:at 1533919515671) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1533919515671) (:by |rJG4IHzWf) (:text |:store)
-                              |j $ %{} :Leaf (:at 1533919515671) (:by |rJG4IHzWf) (:text |@*reel)
-        |reload! $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1626769370991) (:by |rJG4IHzWf)
-            :data $ {}
-              |D $ %{} :Leaf (:at 1626769371841) (:by |rJG4IHzWf) (:text |defn)
-              |L $ %{} :Leaf (:at 1626769373262) (:by |rJG4IHzWf) (:text |reload!)
-              |P $ %{} :Expr (:at 1626769373822) (:by |rJG4IHzWf)
-                :data $ {}
-              |T $ %{} :Expr (:at 1626769375567) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1626769376072) (:by |rJG4IHzWf) (:text |if)
-                  |L $ %{} :Expr (:at 1626769376464) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1626769377296) (:by |rJG4IHzWf) (:text |some?)
-                      |j $ %{} :Leaf (:at 1626769380429) (:by |rJG4IHzWf) (:text |build-errors)
-                  |P $ %{} :Expr (:at 1626769381420) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1626769383551) (:by |rJG4IHzWf) (:text |tip!)
-                      |b $ %{} :Leaf (:at 1626769407621) (:by |rJG4IHzWf) (:text "|\"error")
-                      |j $ %{} :Leaf (:at 1626769386097) (:by |rJG4IHzWf) (:text |build-errors)
-                  |T $ %{} :Expr (:at 1626769388510) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1626769388962) (:by |rJG4IHzWf) (:text |do)
-                      |L $ %{} :Expr (:at 1626769389912) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1626769431965) (:by |rJG4IHzWf) (:text |tip!)
-                          |b $ %{} :Leaf (:at 1626769399420) (:by |rJG4IHzWf) (:text "|\"inactive")
-                          |j $ %{} :Leaf (:at 1626769395996) (:by |rJG4IHzWf) (:text |nil)
-                      |T $ %{} :Expr (:at 1614610459743) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1614610461848) (:by |rJG4IHzWf) (:text |remove-watch)
-                          |j $ %{} :Leaf (:at 1614610463332) (:by |rJG4IHzWf) (:text |*reel)
-                          |r $ %{} :Leaf (:at 1614610465053) (:by |rJG4IHzWf) (:text |:changes)
-                      |j $ %{} :Expr (:at 1507461699387) (:by |root)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1507461702453) (:by |root) (:text |clear-cache!)
-                      |r $ %{} :Expr (:at 1614610456287) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1614610456287) (:by |rJG4IHzWf) (:text |add-watch)
-                          |j $ %{} :Leaf (:at 1614610456287) (:by |rJG4IHzWf) (:text |*reel)
-                          |r $ %{} :Leaf (:at 1614610456287) (:by |rJG4IHzWf) (:text |:changes)
-                          |v $ %{} :Expr (:at 1614610456287) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1614610456287) (:by |rJG4IHzWf) (:text |fn)
-                              |j $ %{} :Expr (:at 1614610456287) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1614610456287) (:by |rJG4IHzWf) (:text |reel)
-                                  |j $ %{} :Leaf (:at 1626769447598) (:by |rJG4IHzWf) (:text |prev-reel)
-                              |r $ %{} :Expr (:at 1614610456287) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1626769449990) (:by |rJG4IHzWf) (:text |render-app!)
-                                  |j $ %{} :Leaf (:at 1614610456287) (:by |rJG4IHzWf) (:text |render!)
-                      |v $ %{} :Expr (:at 1507461704162) (:by |root)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1507461706990) (:by |root) (:text |reset!)
-                          |j $ %{} :Leaf (:at 1507461708965) (:by |root) (:text |*reel)
-                          |r $ %{} :Expr (:at 1507461710020) (:by |root)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1507461730190) (:by |root) (:text |refresh-reel)
-                              |j $ %{} :Leaf (:at 1507461719097) (:by |root) (:text |@*reel)
-                              |r $ %{} :Leaf (:at 1507461721870) (:by |root) (:text |schema/store)
-                              |v $ %{} :Leaf (:at 1507461722724) (:by |root) (:text |updater)
-                      |x $ %{} :Expr (:at 1615024896477) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1615024896477) (:by |rJG4IHzWf) (:text |render-app!)
-                          |j $ %{} :Leaf (:at 1615024896477) (:by |rJG4IHzWf) (:text |render!)
-                      |y $ %{} :Expr (:at 1499755354983) (:by nil)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |println)
-                          |j $ %{} :Leaf (:at 1596818890934) (:by |rJG4IHzWf) (:text "||Code updated.")
-        |render-app! $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1499755354983) (:by nil)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |defn)
-              |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |render-app!)
-              |r $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |renderer)
-              |v $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |renderer)
-                  |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |mount-target)
-                  |r $ %{} :Expr (:at 1499755354983) (:by nil)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |comp-container)
-                      |j $ %{} :Leaf (:at 1507400119272) (:by |root) (:text |@*reel)
-                  |v $ %{} :Leaf (:at 1511280017692) (:by |root) (:text |dispatch!)
-        |repeat! $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1610949959548) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1610949959548) (:by |rJG4IHzWf) (:text |defn)
-              |j $ %{} :Leaf (:at 1610949959548) (:by |rJG4IHzWf) (:text |repeat!)
-              |r $ %{} :Expr (:at 1610949959548) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1610949961510) (:by |rJG4IHzWf) (:text |duration)
-                  |j $ %{} :Leaf (:at 1610949962481) (:by |rJG4IHzWf) (:text |cb)
-              |v $ %{} :Expr (:at 1610949963443) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1610949967510) (:by |rJG4IHzWf) (:text |js/setTimeout)
-                  |b $ %{} :Expr (:at 1610949974428) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1610949974737) (:by |rJG4IHzWf) (:text |fn)
-                      |j $ %{} :Expr (:at 1610949974965) (:by |rJG4IHzWf)
-                        :data $ {}
-                      |r $ %{} :Expr (:at 1610949977007) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1610949976824) (:by |rJG4IHzWf) (:text |cb)
-                      |v $ %{} :Expr (:at 1610949978097) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1610949982234) (:by |rJG4IHzWf) (:text |repeat!)
-                          |j $ %{} :Leaf (:at 1610949985594) (:by |rJG4IHzWf) (:text |duration)
-                          |r $ %{} :Leaf (:at 1610949988057) (:by |rJG4IHzWf) (:text |cb)
-                  |j $ %{} :Expr (:at 1610949970393) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1610949970800) (:by |rJG4IHzWf) (:text |*)
-                      |j $ %{} :Leaf (:at 1610949972139) (:by |rJG4IHzWf) (:text |1000)
-                      |r $ %{} :Leaf (:at 1610949973380) (:by |rJG4IHzWf) (:text |duration)
-        |snippets $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1551977434239) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1551977434239) (:by |rJG4IHzWf) (:text |defn)
-              |j $ %{} :Leaf (:at 1551977434239) (:by |rJG4IHzWf) (:text |snippets)
-              |r $ %{} :Expr (:at 1551977434239) (:by |rJG4IHzWf)
-                :data $ {}
-              |v $ %{} :Expr (:at 1551977444630) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1551977458023) (:by |rJG4IHzWf) (:text |println)
-                  |j $ %{} :Leaf (:at 1551977477010) (:by |rJG4IHzWf) (:text |config/cdn?)
-        |ssr? $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1499755354983) (:by nil)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |def)
-              |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |ssr?)
-              |r $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |some?)
-                  |j $ %{} :Expr (:at 1499755354983) (:by nil)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |js/document.querySelector)
-                      |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text ||meta.respo-ssr)
-      :ns $ %{} :CodeEntry (:doc |)
-        :code $ %{} :Expr (:at 1499755354983) (:by nil)
-          :data $ {}
-            |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |ns)
-            |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |app.main)
-            |r $ %{} :Expr (:at 1499755354983) (:by nil)
-              :data $ {}
-                |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:require)
-                |j $ %{} :Expr (:at 1499755354983) (:by nil)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |respo.core)
-                    |r $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:refer)
-                    |v $ %{} :Expr (:at 1499755354983) (:by nil)
-                      :data $ {}
-                        |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |render!)
-                        |r $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |clear-cache!)
-                        |v $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |realize-ssr!)
-                |v $ %{} :Expr (:at 1499755354983) (:by nil)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |app.comp.container)
-                    |r $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:refer)
-                    |v $ %{} :Expr (:at 1499755354983) (:by nil)
-                      :data $ {}
-                        |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |comp-container)
-                |y $ %{} :Expr (:at 1499755354983) (:by nil)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1508556737455) (:by |root) (:text |app.updater)
-                    |r $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:refer)
-                    |v $ %{} :Expr (:at 1499755354983) (:by nil)
-                      :data $ {}
-                        |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |updater)
-                |yT $ %{} :Expr (:at 1499755354983) (:by nil)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |app.schema)
-                    |r $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:as)
-                    |v $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |schema)
-                |yj $ %{} :Expr (:at 1507399674125) (:by |root)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1507399678694) (:by |root) (:text |reel.util)
-                    |r $ %{} :Leaf (:at 1507399680625) (:by |root) (:text |:refer)
-                    |v $ %{} :Expr (:at 1507399680857) (:by |root)
-                      :data $ {}
-                        |j $ %{} :Leaf (:at 1518156292092) (:by |root) (:text |listen-devtools!)
-                |yr $ %{} :Expr (:at 1507399683930) (:by |root)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1507399687162) (:by |root) (:text |reel.core)
-                    |r $ %{} :Leaf (:at 1507399688098) (:by |root) (:text |:refer)
-                    |v $ %{} :Expr (:at 1507399688322) (:by |root)
-                      :data $ {}
-                        |j $ %{} :Leaf (:at 1507399691010) (:by |root) (:text |reel-updater)
-                        |q $ %{} :Leaf (:at 1518156288482) (:by |root) (:text |refresh-reel)
-                |yv $ %{} :Expr (:at 1507399715229) (:by |root)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1507399717674) (:by |root) (:text |reel.schema)
-                    |r $ %{} :Leaf (:at 1507399755750) (:by |root) (:text |:as)
-                    |v $ %{} :Leaf (:at 1507399757678) (:by |root) (:text |reel-schema)
-                |yy $ %{} :Expr (:at 1527788302920) (:by |root)
-                  :data $ {}
-                    |j $ %{} :Leaf (:at 1664705581604) (:by |rJG4IHzWf) (:text |app.config)
-                    |r $ %{} :Leaf (:at 1527788306048) (:by |root) (:text |:as)
-                    |v $ %{} :Leaf (:at 1527788306884) (:by |root) (:text |config)
-                |yyT $ %{} :Expr (:at 1626769361295) (:by |rJG4IHzWf)
-                  :data $ {}
-                    |T $ %{} :Leaf (:at 1626769365198) (:by |rJG4IHzWf) (:text "|\"bottom-tip")
-                    |j $ %{} :Leaf (:at 1626769424391) (:by |rJG4IHzWf) (:text |:default)
-                    |r $ %{} :Leaf (:at 1626769367052) (:by |rJG4IHzWf) (:text |tip!)
-                |yyj $ %{} :Expr (:at 1626769410401) (:by |rJG4IHzWf)
-                  :data $ {}
-                    |T $ %{} :Leaf (:at 1626769418150) (:by |rJG4IHzWf) (:text "|\"./calcit.build-errors")
-                    |j $ %{} :Leaf (:at 1626769421231) (:by |rJG4IHzWf) (:text |:default)
-                    |r $ %{} :Leaf (:at 1626769421925) (:by |rJG4IHzWf) (:text |build-errors)
-    |app.schema $ %{} :FileEntry
+        |*reel $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defatom *reel $ -> reel-schema/reel (assoc :base schema/store) (assoc :store schema/store)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |dispatch! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn dispatch! (op)
+              when (and config/dev?) (js/console.log |Dispatch: op)
+              reset! *reel $ reel-updater updater @*reel op
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |main! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn main! ()
+              if config/dev? $ load-console-formatter!
+              println "|Running mode:" $ if config/dev? |dev |release
+              if ssr? $ render-app! realize-ssr!
+              render-app! render!
+              add-watch *reel :changes $ fn (reel prev-reel) (render-app! render!)
+              listen-devtools! |a dispatch!
+              ; .addEventListener js/window |beforeunload persist-storage!
+              ; repeat! 60 persist-storage!
+              ; let
+                (raw (js/localStorage.getItem (:storage-key config/site)))
+                when (some? raw)
+                  dispatch! $ :: :hydrate-storage
+                    extract-cirru-data $ js/JSON.parse raw
+              println "|App started."
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |mount-target $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            def mount-target $ js/document.querySelector |.app
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |persist-storage! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn persist-storage! () $ ; .setItem js/localStorage (:storage-key config/site)
+              js/JSON.stringify $ to-calcit-data (:store @*reel)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |reload! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn reload! () $ if (some? build-errors) (tip! |error build-errors)
+              do (tip! |inactive nil) (remove-watch *reel :changes) (clear-cache!)
+                add-watch *reel :changes $ fn (reel prev-reel) (render-app! render!)
+                reset! *reel $ refresh-reel @*reel schema/store updater
+                render-app! render!
+                println "|Code updated."
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |render-app! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn render-app! (renderer)
+              renderer mount-target (comp-container @*reel) dispatch!
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |repeat! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn repeat! (duration cb)
+              js/setTimeout
+                fn () (cb) (repeat! duration cb)
+                * 1000 duration
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |snippets $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn snippets () $ println config/cdn?
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |ssr? $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            def ssr? $ some? (js/document.querySelector |meta.respo-ssr)
+          :examples $ []
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
+        :code $ quote
+          ns app.main $ :require
+            respo.core :refer $ render! clear-cache! realize-ssr!
+            app.comp.container :refer $ comp-container
+            app.updater :refer $ updater
+            app.schema :as schema
+            reel.util :refer $ listen-devtools!
+            reel.core :refer $ reel-updater refresh-reel
+            reel.schema :as reel-schema
+            app.config :as config
+            |bottom-tip :default tip!
+            |./calcit.build-errors :default build-errors
+    |app.schema $ %{} 'FileEntry
       :defs $ {}
-        |add-tags $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1690396592220) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1690396592220) (:by |rJG4IHzWf) (:text |defn)
-              |b $ %{} :Leaf (:at 1697133302642) (:by |rJG4IHzWf) (:text |add-tags)
-              |h $ %{} :Expr (:at 1690396592220) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1690396596425) (:by |rJG4IHzWf) (:text |t)
-                  |b $ %{} :Leaf (:at 1690396598716) (:by |rJG4IHzWf) (:text |data)
-              |l $ %{} :Expr (:at 1690396599666) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1690396599666) (:by |rJG4IHzWf) (:text |map)
-                  |X $ %{} :Leaf (:at 1690396602099) (:by |rJG4IHzWf) (:text |data)
-                  |b $ %{} :Expr (:at 1690396599666) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690396599666) (:by |rJG4IHzWf) (:text |fn)
-                      |b $ %{} :Expr (:at 1690396599666) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1690396599666) (:by |rJG4IHzWf) (:text |item)
-                      |h $ %{} :Expr (:at 1690397342432) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |D $ %{} :Leaf (:at 1690397343128) (:by |rJG4IHzWf) (:text |->)
-                          |L $ %{} :Leaf (:at 1690397351298) (:by |rJG4IHzWf) (:text |item)
-                          |T $ %{} :Expr (:at 1690396599666) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690396599666) (:by |rJG4IHzWf) (:text |update)
-                              |h $ %{} :Leaf (:at 1690396599666) (:by |rJG4IHzWf) (:text |:tags)
-                              |l $ %{} :Expr (:at 1690396599666) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1690396599666) (:by |rJG4IHzWf) (:text |fn)
-                                  |b $ %{} :Expr (:at 1690396599666) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1690396607809) (:by |rJG4IHzWf) (:text |ts)
-                                  |h $ %{} :Expr (:at 1690396599666) (:by |rJG4IHzWf)
-                                    :data $ {}
-                                      |T $ %{} :Leaf (:at 1690396840115) (:by |rJG4IHzWf) (:text |include)
-                                      |b $ %{} :Leaf (:at 1690396608823) (:by |rJG4IHzWf) (:text |ts)
-                                      |h $ %{} :Leaf (:at 1690396609659) (:by |rJG4IHzWf) (:text |t)
-                          |b $ %{} :Expr (:at 1690397354041) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690397354777) (:by |rJG4IHzWf) (:text |assoc)
-                              |b $ %{} :Leaf (:at 1690397356737) (:by |rJG4IHzWf) (:text |:source)
-                              |h $ %{} :Leaf (:at 1690397358109) (:by |rJG4IHzWf) (:text |t)
-        |apis-data $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1611040177451) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1611040177451) (:by |rJG4IHzWf) (:text |def)
-              |j $ %{} :Leaf (:at 1697133137587) (:by |rJG4IHzWf) (:text |apis-data)
-              |r $ %{} :Expr (:at 1629457494708) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1690396695379) (:by |rJG4IHzWf) (:text |concat)
-                  |L $ %{} :Expr (:at 1690396698440) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1697133155226) (:by |rJG4IHzWf) (:text |slurp-cirru-code)
-                      |b $ %{} :Leaf (:at 1690396698440) (:by |rJG4IHzWf) (:text "|\"docs/apis.cirru")
-                  |P $ %{} :Expr (:at 1690396701918) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690396701918) (:by |rJG4IHzWf) (:text |add-tags)
-                      |b $ %{} :Leaf (:at 1690396701918) (:by |rJG4IHzWf) (:text |:internal)
-                      |h $ %{} :Expr (:at 1690396701918) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1697133159539) (:by |rJG4IHzWf) (:text |slurp-cirru-code)
-                          |b $ %{} :Leaf (:at 1690396701918) (:by |rJG4IHzWf) (:text "|\"docs/internals.cirru")
-                  |R $ %{} :Expr (:at 1690396704389) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690396704389) (:by |rJG4IHzWf) (:text |add-tags)
-                      |b $ %{} :Leaf (:at 1690396704389) (:by |rJG4IHzWf) (:text |:list)
-                      |h $ %{} :Expr (:at 1690396704389) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1697133163383) (:by |rJG4IHzWf) (:text |slurp-cirru-code)
-                          |b $ %{} :Leaf (:at 1690396704389) (:by |rJG4IHzWf) (:text "|\"docs/class-list.cirru")
-                  |S $ %{} :Expr (:at 1690396706754) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690396706754) (:by |rJG4IHzWf) (:text |add-tags)
-                      |b $ %{} :Leaf (:at 1690396706754) (:by |rJG4IHzWf) (:text |:map)
-                      |h $ %{} :Expr (:at 1697133188039) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1697133188039) (:by |rJG4IHzWf) (:text |slurp-cirru-code)
-                          |b $ %{} :Leaf (:at 1697133188039) (:by |rJG4IHzWf) (:text "|\"docs/class-map.cirru")
-                  |ST $ %{} :Expr (:at 1690396710486) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690396710486) (:by |rJG4IHzWf) (:text |add-tags)
-                      |b $ %{} :Leaf (:at 1690396710486) (:by |rJG4IHzWf) (:text |:set)
-                      |h $ %{} :Expr (:at 1697133183550) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1697133183550) (:by |rJG4IHzWf) (:text |slurp-cirru-code)
-                          |b $ %{} :Leaf (:at 1697133183550) (:by |rJG4IHzWf) (:text "|\"docs/class-set.cirru")
-                  |Sr $ %{} :Expr (:at 1690396724393) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690396724393) (:by |rJG4IHzWf) (:text |add-tags)
-                      |b $ %{} :Leaf (:at 1690396724393) (:by |rJG4IHzWf) (:text |:number)
-                      |h $ %{} :Expr (:at 1697133181055) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1697133181055) (:by |rJG4IHzWf) (:text |slurp-cirru-code)
-                          |b $ %{} :Leaf (:at 1697133181055) (:by |rJG4IHzWf) (:text "|\"docs/class-number.cirru")
-                  |Sv $ %{} :Expr (:at 1690396727604) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690396727604) (:by |rJG4IHzWf) (:text |add-tags)
-                      |b $ %{} :Leaf (:at 1690396727604) (:by |rJG4IHzWf) (:text |:string)
-                      |h $ %{} :Expr (:at 1697133178853) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1697133178853) (:by |rJG4IHzWf) (:text |slurp-cirru-code)
-                          |b $ %{} :Leaf (:at 1697133178853) (:by |rJG4IHzWf) (:text "|\"docs/class-string.cirru")
-                  |Sx $ %{} :Expr (:at 1690396731333) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690396731333) (:by |rJG4IHzWf) (:text |add-tags)
-                      |b $ %{} :Leaf (:at 1690396731333) (:by |rJG4IHzWf) (:text |:nil)
-                      |h $ %{} :Expr (:at 1697133176491) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1697133176491) (:by |rJG4IHzWf) (:text |slurp-cirru-code)
-                          |b $ %{} :Leaf (:at 1697133176491) (:by |rJG4IHzWf) (:text "|\"docs/class-nil.cirru")
-                  |T $ %{} :Expr (:at 1690396735263) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690396735263) (:by |rJG4IHzWf) (:text |add-tags)
-                      |b $ %{} :Leaf (:at 1690396735263) (:by |rJG4IHzWf) (:text |:fn)
-                      |h $ %{} :Expr (:at 1697133174247) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1697133174247) (:by |rJG4IHzWf) (:text |slurp-cirru-code)
-                          |b $ %{} :Leaf (:at 1697133174247) (:by |rJG4IHzWf) (:text "|\"docs/class-fn.cirru")
-        |slurp-cirru-code $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1610950060783) (:by |rJG4IHzWf)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1610950070005) (:by |rJG4IHzWf) (:text |defmacro)
-              |j $ %{} :Leaf (:at 1697133197435) (:by |rJG4IHzWf) (:text |slurp-cirru-code)
-              |r $ %{} :Expr (:at 1610950060783) (:by |rJG4IHzWf)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1610950062962) (:by |rJG4IHzWf) (:text |file)
-              |v $ %{} :Expr (:at 1697133208700) (:by |rJG4IHzWf)
-                :data $ {}
-                  |D $ %{} :Leaf (:at 1697133213079) (:by |rJG4IHzWf) (:text |&data-to-code)
-                  |T $ %{} :Expr (:at 1697133199495) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |D $ %{} :Leaf (:at 1697133205733) (:by |rJG4IHzWf) (:text |parse-cirru-edn)
-                      |T $ %{} :Expr (:at 1610951527391) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1610951527391) (:by |rJG4IHzWf) (:text |read-file)
-                          |j $ %{} :Leaf (:at 1610951527391) (:by |rJG4IHzWf) (:text |file)
-        |store $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1499755354983) (:by nil)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |def)
-              |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |store)
-              |r $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |{})
-                  |j $ %{} :Expr (:at 1499755354983) (:by nil)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |:states)
-                      |j $ %{} :Expr (:at 1499755354983) (:by nil)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |{})
-                          |j $ %{} :Expr (:at 1584781004285) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1584781007054) (:by |rJG4IHzWf) (:text |:cursor)
-                              |j $ %{} :Expr (:at 1584781007287) (:by |rJG4IHzWf)
-                                :data $ {}
-                                  |T $ %{} :Leaf (:at 1584781007486) (:by |rJG4IHzWf) (:text |[])
-      :ns $ %{} :CodeEntry (:doc |)
-        :code $ %{} :Expr (:at 1499755354983) (:by nil)
-          :data $ {}
-            |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |ns)
-            |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |app.schema)
-    |app.updater $ %{} :FileEntry
+        |add-tags $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn add-tags (t data)
+              map data $ fn (item)
+                -> item
+                  update :tags $ fn (ts) (include ts t)
+                  assoc :source t
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |apis-data $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            def apis-data $ concat (slurp-cirru-code |docs/apis.cirru)
+              add-tags :internal $ slurp-cirru-code |docs/internals.cirru
+              add-tags :list $ slurp-cirru-code |docs/class-list.cirru
+              add-tags :map $ slurp-cirru-code |docs/class-map.cirru
+              add-tags :set $ slurp-cirru-code |docs/class-set.cirru
+              add-tags :number $ slurp-cirru-code |docs/class-number.cirru
+              add-tags :string $ slurp-cirru-code |docs/class-string.cirru
+              add-tags :nil $ slurp-cirru-code |docs/class-nil.cirru
+              add-tags :fn $ slurp-cirru-code |docs/class-fn.cirru
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |slurp-cirru-code $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defmacro slurp-cirru-code (file)
+              &data-to-code $ parse-cirru-edn (read-file file)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |store $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            def store $ {}
+              :states $ {}
+                :cursor $ []
+          :examples $ []
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
+        :code $ quote (ns app.schema)
+    |app.updater $ %{} 'FileEntry
       :defs $ {}
-        |updater $ %{} :CodeEntry (:doc |)
-          :code $ %{} :Expr (:at 1499755354983) (:by nil)
-            :data $ {}
-              |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |defn)
-              |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |updater)
-              |r $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |store)
-                  |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |op)
-                  |v $ %{} :Leaf (:at 1519489491135) (:by |root) (:text |op-id)
-                  |x $ %{} :Leaf (:at 1519489492110) (:by |root) (:text |op-time)
-              |v $ %{} :Expr (:at 1499755354983) (:by nil)
-                :data $ {}
-                  |T $ %{} :Leaf (:at 1690396381989) (:by |rJG4IHzWf) (:text |tag-match)
-                  |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |op)
-                  |n $ %{} :Expr (:at 1507399852251) (:by |root)
-                    :data $ {}
-                      |T $ %{} :Expr (:at 1690396401917) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1507399855618) (:by |root) (:text |:states)
-                          |b $ %{} :Leaf (:at 1690396403745) (:by |rJG4IHzWf) (:text |cursor)
-                          |h $ %{} :Leaf (:at 1690396404019) (:by |rJG4IHzWf) (:text |s)
-                      |j $ %{} :Expr (:at 1584874625235) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1584874626558) (:by |rJG4IHzWf) (:text |update-states)
-                          |j $ %{} :Leaf (:at 1584874628374) (:by |rJG4IHzWf) (:text |store)
-                          |r $ %{} :Leaf (:at 1690396407352) (:by |rJG4IHzWf) (:text |cursor)
-                          |t $ %{} :Leaf (:at 1690396407928) (:by |rJG4IHzWf) (:text |s)
-                  |t $ %{} :Expr (:at 1518157547521) (:by |root)
-                    :data $ {}
-                      |T $ %{} :Expr (:at 1690396399392) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |T $ %{} :Leaf (:at 1518157657108) (:by |root) (:text |:hydrate-storage)
-                          |b $ %{} :Leaf (:at 1690396400285) (:by |rJG4IHzWf) (:text |data)
-                      |j $ %{} :Leaf (:at 1584874637339) (:by |rJG4IHzWf) (:text |data)
-                  |u $ %{} :Expr (:at 1690396386706) (:by |rJG4IHzWf)
-                    :data $ {}
-                      |T $ %{} :Leaf (:at 1690396387138) (:by |rJG4IHzWf) (:text |_)
-                      |b $ %{} :Expr (:at 1690396387692) (:by |rJG4IHzWf)
-                        :data $ {}
-                          |D $ %{} :Leaf (:at 1690396389165) (:by |rJG4IHzWf) (:text |do)
-                          |L $ %{} :Expr (:at 1690396389540) (:by |rJG4IHzWf)
-                            :data $ {}
-                              |T $ %{} :Leaf (:at 1690396390847) (:by |rJG4IHzWf) (:text |eprintln)
-                              |b $ %{} :Leaf (:at 1690396396025) (:by |rJG4IHzWf) (:text "|\"Unknown op:")
-                              |h $ %{} :Leaf (:at 1690396397197) (:by |rJG4IHzWf) (:text |op)
-                          |T $ %{} :Leaf (:at 1690396387692) (:by |rJG4IHzWf) (:text |store)
-      :ns $ %{} :CodeEntry (:doc |)
-        :code $ %{} :Expr (:at 1499755354983) (:by nil)
-          :data $ {}
-            |T $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |ns)
-            |j $ %{} :Leaf (:at 1499755354983) (:by |root) (:text |app.updater)
-            |r $ %{} :Expr (:at 1584874614885) (:by |rJG4IHzWf)
-              :data $ {}
-                |T $ %{} :Leaf (:at 1584874616480) (:by |rJG4IHzWf) (:text |:require)
-                |j $ %{} :Expr (:at 1584874616720) (:by |rJG4IHzWf)
-                  :data $ {}
-                    |T $ %{} :Leaf (:at 1584874616895) (:by |rJG4IHzWf) (:text |[])
-                    |j $ %{} :Leaf (:at 1584874620034) (:by |rJG4IHzWf) (:text |respo.cursor)
-                    |r $ %{} :Leaf (:at 1584874621356) (:by |rJG4IHzWf) (:text |:refer)
-                    |v $ %{} :Expr (:at 1584874621524) (:by |rJG4IHzWf)
-                      :data $ {}
-                        |T $ %{} :Leaf (:at 1584874621745) (:by |rJG4IHzWf) (:text |[])
-                        |j $ %{} :Leaf (:at 1584874623096) (:by |rJG4IHzWf) (:text |update-states)
-  :users $ {}
-    |rJG4IHzWf $ {} (:avatar nil) (:id |rJG4IHzWf) (:name |chen) (:nickname |chen) (:password |d41d8cd98f00b204e9800998ecf8427e) (:theme :star-trail)
-    |root $ {} (:avatar nil) (:id |root) (:name |root) (:nickname |root) (:password |d41d8cd98f00b204e9800998ecf8427e) (:theme :star-trail)
+        |updater $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn updater (store op op-id op-time)
+              tag-match op
+                (:states cursor s) (update-states store cursor s)
+                (:hydrate-storage data) data
+                _ $ do (eprintln "|Unknown op:" op) store
+          :examples $ []
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
+        :code $ quote
+          ns app.updater $ :require
+            [] respo.cursor :refer $ [] update-states

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -2,7 +2,7 @@
 {} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app) (:version |0.0.1)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'app.main/main!) (:mode :native) (:reload-fn 'app.main/reload!)
-      :modules $ [] |lilac/compact.cirru |memof/compact.cirru |respo.calcit/compact.cirru |respo-ui.calcit/compact.cirru |respo-markdown.calcit/compact.cirru |calcit-theme.calcit/compact.cirru |reel.calcit/compact.cirru |respo-feather.calcit/
+      :modules $ [] |lilac/ |memof/ |respo.calcit/ |respo-ui.calcit/ |respo-markdown.calcit/ |calcit-theme.calcit/ |reel.calcit/ |respo-feather.calcit/
       :type-slots $ {}
   :files $ {}
     |app.comp.container $ %{} 'FileEntry

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,10 +1,10 @@
 
-{} (:calcit-version |0.12.33)
+{} (:calcit-version |0.13.19)
   :dependencies $ {} (|Cirru/calcit-theme.calcit |0.4.2)
     |Respo/reel.calcit |main
     |Respo/respo-feather.calcit |main
-    |Respo/respo-markdown.calcit |0.4.11
-    |Respo/respo-ui.calcit |0.6.4
-    |Respo/respo.calcit |0.16.42
-    |calcit-lang/lilac |0.5.1
-    |calcit-lang/memof |0.0.23
+    |Respo/respo-markdown.calcit |0.4.22
+    |Respo/respo-ui.calcit |0.7.7
+    |Respo/respo.calcit |0.16.72
+    |calcit-lang/lilac |main
+    |calcit-lang/memof |0.0.26

--- a/package.json
+++ b/package.json
@@ -1,14 +1,13 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.12.33",
+    "@calcit/procs": "^0.13.19",
     "cirru-color": "^0.2.4",
     "copy-text-to-clipboard": "^3.2.2",
-    "dayjs": "^1.11.20",
     "feather-icons": "^4.29.2"
   },
   "devDependencies": {
     "bottom-tip": "^0.1.5",
-    "vite": "^8.0.11"
+    "vite": "^7.3.1"
   },
   "version": "0.0.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.12.33":
-  version: 0.12.33
-  resolution: "@calcit/procs@npm:0.12.33"
+"@calcit/procs@npm:^0.13.19":
+  version: 0.13.19
+  resolution: "@calcit/procs@npm:0.13.19"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/a3db5fd223eef14f622c4a670c3a074a4f587f96bb27a980091e0e5dab2751c79bdd3375816fa00ff1932fc4b6c84189940c3240e97ded41d2edf57b6ad67640
+  checksum: 10c0/72f17208989f8e2e78462cce625b88fcb5c1635eb04a219f49c954a7c4abc7b0c1bce186d325978a4067d3840e02f3cbf913958828a5a4c543f00bc524c9a9fd
   languageName: node
   linkType: hard
 
@@ -37,31 +37,185 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@emnapi/core@npm:1.10.0"
-  dependencies:
-    "@emnapi/wasi-threads": "npm:1.2.1"
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/f51d08227857b60632de7714d708124f0e100a1462dde6df8221760939aa3204a73193830371830fac0716f3ccd2129f2cac1b17cd7d7958bc4da9018a296edb
+"@esbuild/aix-ppc64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/aix-ppc64@npm:0.27.2"
+  conditions: os=aix & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@emnapi/runtime@npm:1.10.0"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
+"@esbuild/android-arm64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/android-arm64@npm:0.27.2"
+  conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@emnapi/wasi-threads@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@emnapi/wasi-threads@npm:1.2.1"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
+"@esbuild/android-arm@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/android-arm@npm:0.27.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/android-x64@npm:0.27.2"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/darwin-arm64@npm:0.27.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/darwin-x64@npm:0.27.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/freebsd-x64@npm:0.27.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/linux-arm64@npm:0.27.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/linux-arm@npm:0.27.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/linux-ia32@npm:0.27.2"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/linux-loong64@npm:0.27.2"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/linux-mips64el@npm:0.27.2"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/linux-ppc64@npm:0.27.2"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/linux-riscv64@npm:0.27.2"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/linux-s390x@npm:0.27.2"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/linux-x64@npm:0.27.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.2"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/netbsd-x64@npm:0.27.2"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.2"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/openbsd-x64@npm:0.27.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.2"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/sunos-x64@npm:0.27.2"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/win32-arm64@npm:0.27.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/win32-ia32@npm:0.27.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.27.2":
+  version: 0.27.2
+  resolution: "@esbuild/win32-x64@npm:0.27.2"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -90,18 +244,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
-  dependencies:
-    "@tybys/wasm-util": "npm:^0.10.1"
-  peerDependencies:
-    "@emnapi/core": ^1.7.1
-    "@emnapi/runtime": ^1.7.1
-  checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
-  languageName: node
-  linkType: hard
-
 "@npmcli/agent@npm:^4.0.0":
   version: 4.0.0
   resolution: "@npmcli/agent@npm:4.0.0"
@@ -124,135 +266,185 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-project/types@npm:=0.128.0":
-  version: 0.128.0
-  resolution: "@oxc-project/types@npm:0.128.0"
-  checksum: 10c0/b6999b1b6b012d979364231a2c0c9204bca814a73f8417234edd39bf352a081779dad72aaf18ac60a676fb904c1408b63553e4e1230d7408a4f885002d66c809
+"@rollup/rollup-android-arm-eabi@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.56.0"
+  conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@rolldown/binding-android-arm64@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.18"
+"@rollup/rollup-android-arm64@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-android-arm64@npm:4.56.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-arm64@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.18"
+"@rollup/rollup-darwin-arm64@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.56.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-x64@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.18"
+"@rollup/rollup-darwin-x64@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-darwin-x64@npm:4.56.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-freebsd-x64@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.18"
+"@rollup/rollup-freebsd-arm64@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.56.0"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-x64@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.56.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.18"
-  conditions: os=linux & cpu=arm
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.56.0"
+  conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.18"
+"@rollup/rollup-linux-arm-musleabihf@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.56.0"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-gnu@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.56.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.18"
+"@rollup/rollup-linux-arm64-musl@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.56.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.18"
+"@rollup/rollup-linux-loong64-gnu@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.56.0"
+  conditions: os=linux & cpu=loong64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-musl@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.56.0"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-gnu@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.56.0"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.18"
+"@rollup/rollup-linux-ppc64-musl@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.56.0"
+  conditions: os=linux & cpu=ppc64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-gnu@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.56.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-musl@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.56.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.56.0"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.18"
+"@rollup/rollup-linux-x64-gnu@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.56.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.18"
+"@rollup/rollup-linux-x64-musl@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.56.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.18"
+"@rollup/rollup-openbsd-x64@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.56.0"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openharmony-arm64@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.56.0"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.18"
-  dependencies:
-    "@emnapi/core": "npm:1.10.0"
-    "@emnapi/runtime": "npm:1.10.0"
-    "@napi-rs/wasm-runtime": "npm:^1.1.4"
-  conditions: cpu=wasm32
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.18"
+"@rollup/rollup-win32-arm64-msvc@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.56.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.18"
+"@rollup/rollup-win32-ia32-msvc@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.56.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-gnu@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.56.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@rolldown/pluginutils@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.18"
-  checksum: 10c0/c09f2ebe53762df23b725f452a3f7ee45968824b062a38ec06054e368551e8c5e1874b0ef28143ff3b1b9d6d5ca60177a34378bdd672e899c3646fb8d0bd5aff
+"@rollup/rollup-win32-x64-msvc@npm:4.56.0":
+  version: 4.56.0
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.56.0"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@tybys/wasm-util@npm:^0.10.1":
-  version: 0.10.2
-  resolution: "@tybys/wasm-util@npm:0.10.2"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/26165bcd1fd7269f42d7fbe3de318f854a8968de8397e89fc9a423bb3e2da35a52150f382e6323b3367595beb16d9800a6f35971a5599daf76da1742ec3afc25
+"@types/estree@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@types/estree@npm:1.0.8"
+  checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
   languageName: node
   linkType: hard
 
@@ -348,13 +540,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.11.20":
-  version: 1.11.20
-  resolution: "dayjs@npm:1.11.20"
-  checksum: 10c0/8af525e2aa100c8db9923d706c42b2b2d30579faf89456619413a5c10916efc92c2b166e193c27c02eb3174b30aa440ee1e7b72b0a2876b3da651d204db848a0
-  languageName: node
-  linkType: hard
-
 "debug@npm:4, debug@npm:^4.3.4":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
@@ -364,13 +549,6 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
-  languageName: node
-  linkType: hard
-
-"detect-libc@npm:^2.0.3":
-  version: 2.1.2
-  resolution: "detect-libc@npm:2.1.2"
-  checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
   languageName: node
   linkType: hard
 
@@ -412,6 +590,95 @@ __metadata:
     string-template: "npm:~0.2.0"
     xtend: "npm:~4.0.0"
   checksum: 10c0/6aecddafbc14db142a47df295b2d832630dd4af6ec62a52dbf00eefa7adea249a3182a6c920c5e24974204f7234d02ed2b073f6f8eb164ba2e620d93218e2e66
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.27.0":
+  version: 0.27.2
+  resolution: "esbuild@npm:0.27.2"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.27.2"
+    "@esbuild/android-arm": "npm:0.27.2"
+    "@esbuild/android-arm64": "npm:0.27.2"
+    "@esbuild/android-x64": "npm:0.27.2"
+    "@esbuild/darwin-arm64": "npm:0.27.2"
+    "@esbuild/darwin-x64": "npm:0.27.2"
+    "@esbuild/freebsd-arm64": "npm:0.27.2"
+    "@esbuild/freebsd-x64": "npm:0.27.2"
+    "@esbuild/linux-arm": "npm:0.27.2"
+    "@esbuild/linux-arm64": "npm:0.27.2"
+    "@esbuild/linux-ia32": "npm:0.27.2"
+    "@esbuild/linux-loong64": "npm:0.27.2"
+    "@esbuild/linux-mips64el": "npm:0.27.2"
+    "@esbuild/linux-ppc64": "npm:0.27.2"
+    "@esbuild/linux-riscv64": "npm:0.27.2"
+    "@esbuild/linux-s390x": "npm:0.27.2"
+    "@esbuild/linux-x64": "npm:0.27.2"
+    "@esbuild/netbsd-arm64": "npm:0.27.2"
+    "@esbuild/netbsd-x64": "npm:0.27.2"
+    "@esbuild/openbsd-arm64": "npm:0.27.2"
+    "@esbuild/openbsd-x64": "npm:0.27.2"
+    "@esbuild/openharmony-arm64": "npm:0.27.2"
+    "@esbuild/sunos-x64": "npm:0.27.2"
+    "@esbuild/win32-arm64": "npm:0.27.2"
+    "@esbuild/win32-ia32": "npm:0.27.2"
+    "@esbuild/win32-x64": "npm:0.27.2"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/cf83f626f55500f521d5fe7f4bc5871bec240d3deb2a01fbd379edc43b3664d1167428738a5aad8794b35d1cca985c44c375b1cd38a2ca613c77ced2c83aafcd
   languageName: node
   linkType: hard
 
@@ -462,7 +729,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.3":
+"fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -472,7 +739,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -577,126 +844,6 @@ __metadata:
   version: 3.1.4
   resolution: "isexe@npm:3.1.4"
   checksum: 10c0/6e1f78dd794118d263319c27c26a339eda6855b43e11e1a9013cb68578ce0396b74f11ea635e52b9466fb48a60abe70f3c9faf682f67988be092cf89b7c0dc1c
-  languageName: node
-  linkType: hard
-
-"lightningcss-android-arm64@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-android-arm64@npm:1.32.0"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"lightningcss-darwin-arm64@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-darwin-arm64@npm:1.32.0"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"lightningcss-darwin-x64@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-darwin-x64@npm:1.32.0"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"lightningcss-freebsd-x64@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-freebsd-x64@npm:1.32.0"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"lightningcss-linux-arm-gnueabihf@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.32.0"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"lightningcss-linux-arm64-gnu@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-arm64-gnu@npm:1.32.0"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"lightningcss-linux-arm64-musl@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-arm64-musl@npm:1.32.0"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"lightningcss-linux-x64-gnu@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-x64-gnu@npm:1.32.0"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"lightningcss-linux-x64-musl@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-x64-musl@npm:1.32.0"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"lightningcss-win32-arm64-msvc@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-win32-arm64-msvc@npm:1.32.0"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"lightningcss-win32-x64-msvc@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-win32-x64-msvc@npm:1.32.0"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"lightningcss@npm:^1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss@npm:1.32.0"
-  dependencies:
-    detect-libc: "npm:^2.0.3"
-    lightningcss-android-arm64: "npm:1.32.0"
-    lightningcss-darwin-arm64: "npm:1.32.0"
-    lightningcss-darwin-x64: "npm:1.32.0"
-    lightningcss-freebsd-x64: "npm:1.32.0"
-    lightningcss-linux-arm-gnueabihf: "npm:1.32.0"
-    lightningcss-linux-arm64-gnu: "npm:1.32.0"
-    lightningcss-linux-arm64-musl: "npm:1.32.0"
-    lightningcss-linux-x64-gnu: "npm:1.32.0"
-    lightningcss-linux-x64-musl: "npm:1.32.0"
-    lightningcss-win32-arm64-msvc: "npm:1.32.0"
-    lightningcss-win32-x64-msvc: "npm:1.32.0"
-  dependenciesMeta:
-    lightningcss-android-arm64:
-      optional: true
-    lightningcss-darwin-arm64:
-      optional: true
-    lightningcss-darwin-x64:
-      optional: true
-    lightningcss-freebsd-x64:
-      optional: true
-    lightningcss-linux-arm-gnueabihf:
-      optional: true
-    lightningcss-linux-arm64-gnu:
-      optional: true
-    lightningcss-linux-arm64-musl:
-      optional: true
-    lightningcss-linux-x64-gnu:
-      optional: true
-    lightningcss-linux-x64-musl:
-      optional: true
-    lightningcss-win32-arm64-msvc:
-      optional: true
-    lightningcss-win32-x64-msvc:
-      optional: true
-  checksum: 10c0/70945bd55097af46fc9fab7f5ed09cd5869d85940a2acab7ee06d0117004a1d68155708a2d462531cea2fc3c67aefc9333a7068c80b0b78dd404c16838809e03
   languageName: node
   linkType: hard
 
@@ -921,21 +1068,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "picomatch@npm:4.0.4"
-  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.14":
-  version: 8.5.14
-  resolution: "postcss@npm:8.5.14"
+"postcss@npm:^8.5.6":
+  version: 8.5.6
+  resolution: "postcss@npm:8.5.6"
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/48138207cf5ef5581be1bfe2cb65ccfe0ac75e43888ba045afc8ed6043d7b56aeb3b9a9fe5b353ff554be943cd0cc15d826ccb991525159175971e5ee8ab0237
+  checksum: 10c0/5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
   languageName: node
   linkType: hard
 
@@ -970,61 +1110,93 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rolldown@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "rolldown@npm:1.0.0-rc.18"
+"rollup@npm:^4.43.0":
+  version: 4.56.0
+  resolution: "rollup@npm:4.56.0"
   dependencies:
-    "@oxc-project/types": "npm:=0.128.0"
-    "@rolldown/binding-android-arm64": "npm:1.0.0-rc.18"
-    "@rolldown/binding-darwin-arm64": "npm:1.0.0-rc.18"
-    "@rolldown/binding-darwin-x64": "npm:1.0.0-rc.18"
-    "@rolldown/binding-freebsd-x64": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-rc.18"
-    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-rc.18"
-    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-rc.18"
-    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-rc.18"
-    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-rc.18"
-    "@rolldown/pluginutils": "npm:1.0.0-rc.18"
+    "@rollup/rollup-android-arm-eabi": "npm:4.56.0"
+    "@rollup/rollup-android-arm64": "npm:4.56.0"
+    "@rollup/rollup-darwin-arm64": "npm:4.56.0"
+    "@rollup/rollup-darwin-x64": "npm:4.56.0"
+    "@rollup/rollup-freebsd-arm64": "npm:4.56.0"
+    "@rollup/rollup-freebsd-x64": "npm:4.56.0"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.56.0"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.56.0"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.56.0"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.56.0"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.56.0"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.56.0"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.56.0"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.56.0"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.56.0"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.56.0"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.56.0"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.56.0"
+    "@rollup/rollup-linux-x64-musl": "npm:4.56.0"
+    "@rollup/rollup-openbsd-x64": "npm:4.56.0"
+    "@rollup/rollup-openharmony-arm64": "npm:4.56.0"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.56.0"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.56.0"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.56.0"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.56.0"
+    "@types/estree": "npm:1.0.8"
+    fsevents: "npm:~2.3.2"
   dependenciesMeta:
-    "@rolldown/binding-android-arm64":
+    "@rollup/rollup-android-arm-eabi":
       optional: true
-    "@rolldown/binding-darwin-arm64":
+    "@rollup/rollup-android-arm64":
       optional: true
-    "@rolldown/binding-darwin-x64":
+    "@rollup/rollup-darwin-arm64":
       optional: true
-    "@rolldown/binding-freebsd-x64":
+    "@rollup/rollup-darwin-x64":
       optional: true
-    "@rolldown/binding-linux-arm-gnueabihf":
+    "@rollup/rollup-freebsd-arm64":
       optional: true
-    "@rolldown/binding-linux-arm64-gnu":
+    "@rollup/rollup-freebsd-x64":
       optional: true
-    "@rolldown/binding-linux-arm64-musl":
+    "@rollup/rollup-linux-arm-gnueabihf":
       optional: true
-    "@rolldown/binding-linux-ppc64-gnu":
+    "@rollup/rollup-linux-arm-musleabihf":
       optional: true
-    "@rolldown/binding-linux-s390x-gnu":
+    "@rollup/rollup-linux-arm64-gnu":
       optional: true
-    "@rolldown/binding-linux-x64-gnu":
+    "@rollup/rollup-linux-arm64-musl":
       optional: true
-    "@rolldown/binding-linux-x64-musl":
+    "@rollup/rollup-linux-loong64-gnu":
       optional: true
-    "@rolldown/binding-openharmony-arm64":
+    "@rollup/rollup-linux-loong64-musl":
       optional: true
-    "@rolldown/binding-wasm32-wasi":
+    "@rollup/rollup-linux-ppc64-gnu":
       optional: true
-    "@rolldown/binding-win32-arm64-msvc":
+    "@rollup/rollup-linux-ppc64-musl":
       optional: true
-    "@rolldown/binding-win32-x64-msvc":
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-openbsd-x64":
+      optional: true
+    "@rollup/rollup-openharmony-arm64":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-gnu":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
       optional: true
   bin:
-    rolldown: bin/cli.mjs
-  checksum: 10c0/699b8545a9a8b85ed4c639122163a6f46f84404fd88262bafa9549b01546744db625fd4425fceb4658c888de1671323170de1f837f6f6bb93e243e6e1d48c114
+    rollup: dist/bin/rollup
+  checksum: 10c0/716554ed5aadb10183b2a2096837bb6d716c6812ebcf04395b4e9e4107a2d975ee7ac7eb8ea3734ad817019e8f0d16df5d2eea5f4239048f45663b5cdea638ed
   languageName: node
   linkType: hard
 
@@ -1032,13 +1204,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.12.33"
+    "@calcit/procs": "npm:^0.13.19"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:^0.2.4"
     copy-text-to-clipboard: "npm:^3.2.2"
-    dayjs: "npm:^1.11.20"
     feather-icons: "npm:^4.29.2"
-    vite: "npm:^8.0.11"
+    vite: "npm:^7.3.1"
   languageName: unknown
   linkType: soft
 
@@ -1122,30 +1293,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12":
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15":
   version: 0.2.15
   resolution: "tinyglobby@npm:0.2.15"
   dependencies:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.3"
   checksum: 10c0/869c31490d0d88eedb8305d178d4c75e7463e820df5a9b9d388291daf93e8b1eb5de1dad1c1e139767e4269fe75f3b10d5009b2cc14db96ff98986920a186844
-  languageName: node
-  linkType: hard
-
-"tinyglobby@npm:^0.2.16":
-  version: 0.2.16
-  resolution: "tinyglobby@npm:0.2.16"
-  dependencies:
-    fdir: "npm:^6.5.0"
-    picomatch: "npm:^4.0.4"
-  checksum: 10c0/f2e09fd93dd95c41e522113b686ff6f7c13020962f8698a864a257f3d7737599afc47722b7ab726e12f8a813f779906187911ff8ee6701ede65072671a7e934b
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.4.0":
-  version: 2.8.1
-  resolution: "tslib@npm:2.8.1"
-  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
   languageName: node
   linkType: hard
 
@@ -1183,22 +1337,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^8.0.11":
-  version: 8.0.11
-  resolution: "vite@npm:8.0.11"
+"vite@npm:^7.3.1":
+  version: 7.3.1
+  resolution: "vite@npm:7.3.1"
   dependencies:
+    esbuild: "npm:^0.27.0"
+    fdir: "npm:^6.5.0"
     fsevents: "npm:~2.3.3"
-    lightningcss: "npm:^1.32.0"
-    picomatch: "npm:^4.0.4"
-    postcss: "npm:^8.5.14"
-    rolldown: "npm:1.0.0-rc.18"
-    tinyglobby: "npm:^0.2.16"
+    picomatch: "npm:^4.0.3"
+    postcss: "npm:^8.5.6"
+    rollup: "npm:^4.43.0"
+    tinyglobby: "npm:^0.2.15"
   peerDependencies:
     "@types/node": ^20.19.0 || >=22.12.0
-    "@vitejs/devtools": ^0.1.18
-    esbuild: ^0.27.0 || ^0.28.0
     jiti: ">=1.21.0"
     less: ^4.0.0
+    lightningcss: ^1.21.0
     sass: ^1.70.0
     sass-embedded: ^1.70.0
     stylus: ">=0.54.8"
@@ -1212,13 +1366,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/node":
       optional: true
-    "@vitejs/devtools":
-      optional: true
-    esbuild:
-      optional: true
     jiti:
       optional: true
     less:
+      optional: true
+    lightningcss:
       optional: true
     sass:
       optional: true
@@ -1236,7 +1388,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/504ec6064761239e7063426dd123ea68cd540cb2d475bf72f5b1062313b9c79984831f56a20891ed5e08b2753d34171ee7a75cbadf9365e975d1f68634f0a10f
+  checksum: 10c0/5c7548f5f43a23533e53324304db4ad85f1896b1bfd3ee32ae9b866bac2933782c77b350eb2b52a02c625c8ad1ddd4c000df077419410650c982cd97fde8d014
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Per `cr docs read upgrade`: `caps upgrade --all` -> `:calcit-version` 0.13.19, deps bumped to latest tags, `@calcit/procs` synced to ^0.13.19. Branch based on `main`; local feature-branch state untouched.